### PR TITLE
Add github app configuration for backstage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,9 @@ jobs:
       run: helm upgrade --install min-postgres-chart ./charts/postgres -f ./charts/postgres/Values.yaml --set postgresUsername=${{ secrets.POSTGRES_USER }} --set postgresPassword=${{ secrets.POSTGRES_PASSWORD }}
 
     - name: Helm Upgrade Backstage (backstage:${{ env.TAG }})
-      run: helm upgrade --install min-backstage-chart ./charts/backstage -f ./charts/backstage/Values.yaml --set backstageImage="$IMAGE:$TAG"
+      run: helm upgrade --install min-backstage-chart ./charts/backstage -f ./charts/backstage/Values.yaml --set backstageImage="$IMAGE:$TAG" --set backstageGithubCredentials="$CREDENTIALS"
+      env:
+        CREDENTIALS: ${{ secrets.BACKSTAGE_GITHUB_APP_CREDENTIALS }}
 
     - name: Confirm Deployment Status
       id: deploy-status

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 
 RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
 
-COPY packages/backend/dist/bundle.tar.gz app-config.yaml ./
+COPY packages/backend/dist/bundle.tar.gz app-config.yaml app-config.production.yaml ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ minikube start
 eval $(minikube docker-env)
 minikube image load backstage:$TAG
 
-# 💥 comment out ./backstate/templates/certificate.yaml
+# TODO - need to modify the charts so that the following steps are automated for local development but for now please do the following manually:
+* 💥 comment out ./backstate/templates/certificate.yaml
+* 💥 comment out ./backstage/templates/secrets.yaml
+* 💥 comment out `volumeMounts` and `volumes`
+* 💥 modify container command to exclude `app-config.production.yaml`
 
 helm upgrade --install min-postgres-chart ./charts/postgres \
   -f ./charts/postgres/Values.yaml \

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -1,0 +1,5 @@
+integrations:
+  github:
+    - host: github.com
+      apps:
+        - $include: credentials/backstage-app-credentials.yaml

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -73,43 +73,11 @@ scaffolder:
   # see https://backstage.io/docs/features/software-templates/configuration for software template options
 
 catalog:
+  # https://backstage.io/docs/features/software-catalog/descriptor-format
   rules:
     - allow: [Component, System, API, Group, User, Resource, Location]
   locations:
-    # Backstage example components
     - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-components.yaml
-
-    # Backstage example systems
+      target: https://github.com/thefrontside/backstage/blob/main/catalog-info.yaml
     - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-systems.yaml
-
-    # Backstage example APIs
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-apis.yaml
-
-    # Backstage example resources
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-resources.yaml
-
-    # Backstage example organization groups
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme/org.yaml
-
-    # Backstage example templates
-    - type: url
-      target: https://github.com/backstage/software-templates/blob/main/scaffolder-templates/react-ssr-template/template.yaml
-      rules:
-        - allow: [Template]
-    - type: url
-      target: https://github.com/backstage/software-templates/blob/main/scaffolder-templates/springboot-grpc-template/template.yaml
-      rules:
-        - allow: [Template]
-    - type: url
-      target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
-      rules:
-        - allow: [Template]
-    - type: url
-      target: https://github.com/backstage/software-templates/blob/main/scaffolder-templates/docs-template/template.yaml
-      rules:
-        - allow: [Template]
+      target: https://github.com/thefrontside/changes/blob/mk/catalog-info.yaml

--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: backstage
         image: {{ required "You must provide a Backstage image" .Values.backstageImage }}
-        command: ["node", "packages/backend", "--config", "app-config.yaml"]
+        command: ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.production.yaml"]
         ports:
           - name: http
             containerPort: {{ .Values.backstagePort | default 7007 }}
@@ -35,6 +35,14 @@ spec:
             port: http
           periodSeconds: 4
           failureThreshold: 15
+        volumeMounts:
+          - mountPath: "/app/credentials"
+            name: "backstage-app-credentials"
+            readOnly: true
+        volumes:
+          - name: "backstage-app-credentials"
+            secret:
+              secretName: backstage-credentials
         env:
           - name: APP_CONFIG_app_baseUrl
             value: {{ .Values.baseUrl }}

--- a/charts/backstage/templates/secrets.yaml
+++ b/charts/backstage/templates/secrets.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backstage-credentials
+data:
+  backstage-app-credentials.yaml: {{ required "You must provide credentials for the Github Frontside Backstage App" .Values.backstageGithubCredentials }}


### PR DESCRIPTION
## Motivation

Integrate Github App to our backstage instance (as opposed to relying on a github personal access token) so backstage can read and take action in our github organization.

## Approach

https://backstage.io/docs/plugins/github-apps

- Installed github app [`Frontside-Backstage`](https://github.com/organizations/thefrontside/settings/installations/23610867)
  - Took the credentials and added it to this repository's action secrets as `BACKSTAGE_GITHUB_APP_CREDENTIALS`
- Created a production app-config file for the github integration to use the github app instead of a personal token
  - Updated dockerfile to include the production app config
- The github app integration requires a `backstage-app-credentials.yaml` file in the `credentials` directory
  - In CI we're passing the new github secret mentioned above to a kubernetes secret object and that secret object is being mounted to the necessary directory to match the path in our backstage's production app-config
- To confirm the integration with the credentials are working properly, I removed all the default catalog components and added two of our own frontside components; `thefrontside/backstage/catalog-info.yaml` (public) and `thefrontside/changes/catalog-info.yaml` (private)