### PR TITLE
Increase failure timeout

### DIFF
--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   name: backstage
 spec:
   replicas: 2
-  progressDeadlineSeconds: 35
-    # 15 initial of startup probe + 15 (5 period x 3) + 5 leeway
+  progressDeadlineSeconds: 60
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -34,8 +33,8 @@ spec:
           httpGet:
             path: /api/healthcheck
             port: http
-          initialDelaySeconds: 15
-          periodSeconds: 5
+          periodSeconds: 4
+          failureThreshold: 15
         env:
           - name: APP_CONFIG_app_baseUrl
             value: {{ .Values.baseUrl }}


### PR DESCRIPTION
## Motivation

The last deployment [failed](https://github.com/thefrontside/backstage/runs/5652953869?check_suite_focus=true#step:12:18) and rolled back to the image of the previous deployment. (Good to see the roll back actually works.)

I pulled the image that failed to deploy and it runs fine in the local cluster. My suspicion is that the timeout is a little too close to the time it actually takes for the container to start.

## Approach

- Increased `progressDeadlineSeconds` from 35 to 60
- Removed `initialDelaySeconds`; don't see why it's necessary unless each probe attempt is too expensive
- Decreased `periodSeconds` (how often the probes shoot off) from 5 to 4
- Added `failureThreshold` and set it to 15
  - The failureThreshold doesn't fail the deployment status but just restarts the pod
    - The default threshold was 3 and this might have been a contributing factor to why the deployment in GCP failed