### PR TITLE
Lift volumes one level higher in deployment chart

### DIFF
--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -39,10 +39,6 @@ spec:
           - mountPath: "/app/credentials"
             name: "backstage-app-credentials"
             readOnly: true
-        volumes:
-          - name: "backstage-app-credentials"
-            secret:
-              secretName: backstage-credentials
         env:
           - name: APP_CONFIG_app_baseUrl
             value: {{ .Values.baseUrl }}
@@ -51,3 +47,7 @@ spec:
         envFrom:
           - secretRef:
               name: postgres-secrets
+      volumes:
+        - name: "backstage-app-credentials"
+          secret:
+            secretName: backstage-credentials


### PR DESCRIPTION
## Motivation

Deployment of github integration PR [failed](https://github.com/thefrontside/backstage/runs/5665184603?check_suite_focus=true#step:10:19) because of a syntax error.

## Approach

`volumes` isn't supposed to be nested under containers