### PR TITLE
Increase deployment deadline to 90 seconds

### DIFF
--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: backstage
 spec:
   replicas: 2
-  progressDeadlineSeconds: 60
+  progressDeadlineSeconds: 90
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Last deployment didn't have enough time to start up. Increased from 60 to 90 seconds.