### PR TITLE
Add githubusercontent to csp to get avatar images

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -16,6 +16,7 @@ backend:
     port: 7007
   csp:
     connect-src: ["'self'", 'http:', 'https:']
+    img-src: ["'self'", 'https://avatars.githubusercontent.com']
     # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
     # Default Helmet Content-Security-Policy values can be removed by setting the key to false
   cors:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29791650/164531216-7ac19a2d-439b-4061-a35d-c850531526a0.png)

Need to add https://avatars.githubsuercontent.com to csp in order for our avatars to be fetched from external sources (i think)