### PR TITLE
Allow local development without worrying about environment variables …

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ To start the Backstage app with Postgres via docker compose, run:
 ```sh
 docker-compose up
 yarn install
-POSTGRES_SERVICE_PORT=5432 POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres yarn dev
+yarn dev
 ```
 
 To start Backstage in your local cluster using minikube, run:

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -1,3 +1,12 @@
+backend:
+  database:
+    client: pg
+    connection:
+      host: ${POSTGRES_SERVICE_HOST}
+      port: ${POSTGRES_SERVICE_PORT}
+      user: ${POSTGRES_USER}
+      password: ${POSTGRES_PASSWORD}
+
 integrations:
   github:
     - host: github.com

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -27,10 +27,10 @@ backend:
   database:
     client: pg
     connection:
-      host: ${POSTGRES_SERVICE_HOST}
-      port: ${POSTGRES_SERVICE_PORT}
-      user: ${POSTGRES_USER}
-      password: ${POSTGRES_PASSWORD}
+      host: localhost
+      port: 5432
+      user: postgres
+      password: postgres
       # https://node-postgres.com/features/ssl
       # you can set the sslmode configuration option via the `PGSSLMODE` environment variable
       # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)


### PR DESCRIPTION
## Motivation

I was doing some local development and I wasn't able to start the backend because I didn't specify environment variables. This was happening because `app-config.yaml` was setup to ask for environment variables for postgres. Frontside configuration should be optimized for developers, not computers. 

## Approach

* Moved environment variables for postgres to `app-config.production.yaml`
* Hardcoded settings from docker-compose.yaml as postgres credentials
* Updated README to remove environment variables
