### PR TITLE
Add preview workflow to publish graphql plugin

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,19 @@
+name: Publish Previews
+
+on: pull_request
+
+jobs:
+  preview:
+    name: Publish Previews
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v2
+      with:
+        registry-url: https://registry.npmjs.org
+    - uses: thefrontside/actions/publish-pr-preview@v2
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,3 @@ site
 
 # Sensitive credentials
 *-credentials.yaml
-
-notes


### PR DESCRIPTION
## Approach
- Added preview workflow using the v2 version of our preview action
- Changed the graphql plugin's package name from `@internal/plugin-graphql` to `@frontside/backstage-plugin-graphql`
- Unrelated to this PR but i also removed notes/ from gitignore. It was added because that's where i kept my personal notes but forgot that's also where we put our docs for the deployment steps

## Future TODOs

- This will only publish previews, we also need to add a release workflow if we want to publish on PR-merges
- The backend package doesn't have the plugin added as a dependency yet