### PR TITLE
Update database on org webhook events too

### DIFF
--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -34,7 +34,7 @@ export default async function createPlugin(
   
   router.post('/github/webhook', async (req, _res) => {
     const event = req.headers["x-github-event"];
-    if (event == "membership") {
+    if (event == "membership" || event == "organization") {
       await gitProvider.read();
       env.logger.info("Successfully triggered database update via github webhook event");
     }


### PR DESCRIPTION
## Motivation

The entity provider is set to update only when the event-type is "membership" but that's only for team-related events (creating/deleting teams, adding/removing members _from_ teams).

## Approach

- Added `if (event == "membership" || event == "organization") { ... }` so the users/groups in the catalog will be updated when new users are added/removed from the frontside organization
- Added `team` webhook events in permissions for the frontside backstage github app (it was currently only sending webhook events for repo and org-related events)