### PR TITLE
Fix compilation errors

### DIFF
--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -7,6 +7,7 @@ export default async function createPlugin({
   database,
   config,
   discovery,
+  tokenManager,
 }: PluginEnvironment): Promise<Router> {
-  return await createRouter({ logger, config, database, discovery });
+  return await createRouter({ logger, config, database, discovery, tokenManager });
 }

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -1,7 +1,5 @@
-import { DockerContainerRunner } from '@backstage/backend-common';
 import { CatalogClient } from '@backstage/catalog-client';
 import { createRouter } from '@backstage/plugin-scaffolder-backend';
-import Docker from 'dockerode';
 import { Router } from 'express';
 import type { PluginEnvironment } from '../types';
 
@@ -12,12 +10,9 @@ export default async function createPlugin({
   reader,
   discovery,
 }: PluginEnvironment): Promise<Router> {
-  const dockerClient = new Docker();
-  const containerRunner = new DockerContainerRunner({ dockerClient });
   const catalogClient = new CatalogClient({ discoveryApi: discovery });
 
   return await createRouter({
-    containerRunner,
     logger,
     config,
     database,


### PR DESCRIPTION
## Motivation
The backstage instance was failing to compile after the upgrade to Backstage 1.0 https://github.com/thefrontside/backstage/pull/14 This impedes deployments and plugin development.

## Approach
In the case of the Auth plugin, the token manager was not being passed in from the plugin environment, and in the case of the scaffolder, it apparently does not accept a docker runner anymore. Pretty straightforward, and hey, TypeScript FTW.