### PR TITLE
Make inspector packages public

### DIFF
--- a/plugins/effection-inspector-backend/package.json
+++ b/plugins/effection-inspector-backend/package.json
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",

--- a/plugins/effection-inspector/package.json
+++ b/plugins/effection-inspector/package.json
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION

## Motivation
We want to publish the inspector packages, but can't because they're private.


## Approach
Make 'em public
