### PR TITLE
🐛Fix types not getting distributed with plugins

### DIFF
--- a/.changeset/packity-pack.md
+++ b/.changeset/packity-pack.md
@@ -1,0 +1,5 @@
+---
+"@frontside/backstage-plugin-effection-inspector": patch
+"@frontside/backstage-plugin-effection-inspector-backend": patch
+---
+ensure build before prepack to properly generate index.d.ts files

--- a/plugins/effection-inspector-backend/package.json
+++ b/plugins/effection-inspector-backend/package.json
@@ -18,7 +18,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
-    "prepack": "backstage-cli package prepack",
+    "prepack": "yarn build && backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {

--- a/plugins/effection-inspector/package.json
+++ b/plugins/effection-inspector/package.json
@@ -18,7 +18,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
-    "prepack": "backstage-cli package prepack",
+    "prepack": "yarn build && backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {


### PR DESCRIPTION
## Motivation

A Backstage installation makes certain assumptions about build order, and long story short, if you run a build from the root, it ends up deleting the `index.d.ts` files of each individual package. This ended up meaning that when our plugins were distributed to NPM, they did not actually contain `index.d.ts` which means that TS projects consuming them get compile errors.

## Approach

This ensures that each of our distributable plugins first does a `build` as part of the packaging for NPM