### PR TITLE
Go back to mainline publish action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         registry-url: https://registry.npmjs.org
-    - uses: thefrontside/actions/synchronize-with-npm@cl/debug
+    - uses: thefrontside/actions/synchronize-with-npm@v2
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation 
There was [a problem](https://github.com/thefrontside/actions/pull/77) with the publish action that was causing it to fail silently and in order to diagnose it, we had to use a debug version. However, once the fix is in, we can revert back to the mainline action.

## Approach
This reverts commit 7597789d591539987751289dd47382ef0551fa21.