### PR TITLE
Secret without bearer and locations should be urls

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,7 +64,7 @@ jobs:
           -f ./charts/backstage/Values.yaml \
           --set backstageImage="$IMAGE:$TAG" \
           --set backstageGithubCredentials="$CREDENTIALS" \
-          --set humanitecToken="Bearer $HUMANITEC_TOKEN"
+          --set humanitecToken="$HUMANITEC_TOKEN"
       env:
         CREDENTIALS: ${{ secrets.BACKSTAGE_GITHUB_APP_CREDENTIALS }}
         HUMANITEC_TOKEN: ${{ secrets.HUMANITEC_TOKEN }}

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -79,9 +79,9 @@ scaffolder:
 
 catalog:
   locations:
-    - type: file
+    - type: url
       target: https://github.com/thefrontside/backstage/blob/main/catalog-info.yaml
-    - type: file
+    - type: url
       target: https://github.com/thefrontside/backstage/blob/main/templates/standard-microservice/template.yaml
       rules:
         - allow: [Template]


### PR DESCRIPTION
## Motivation

I discovered after I deployed that token shouldn't have Bearer in it, because we add that in the app-config.yaml. We also need to make sure that each location is a URL.

## Approach

1. Removed Bearer prefix2. 
2. Changed location type
