### PR TITLE
Configure workflow to use Google Cloud Service Account

### DIFF
--- a/templates/standard-microservice/template/.github/workflows/build-push.yaml
+++ b/templates/standard-microservice/template/.github/workflows/build-push.yaml
@@ -21,11 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Google Cloud Workload Identity Federation
+      - name: Google Cloud Service Account
         uses: google-github-actions/auth@v0
         with:
-          workload_identity_provider: ${{ secrets.HUMAN_CLOUD_PROVIDER }} # 🚨 cloud_workload_provider
-          service_account: ${{ secrets.HUMAN_CLOUD_SERVICE }} # 🚨 cloud_service_account
+          service_account: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT }}
 
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0


### PR DESCRIPTION
## Motivation

We have to use Google Cloud Service Account or Workload Identity Federation.

Since Google Cloud Service Account is easier. I'm using it.

## Approach

Added secret variable called GOOGLE_CLOUD_SERVICE_ACCOUNT
