### PR TITLE
Automatically handle retry

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -54,10 +54,6 @@ proxy:
   '/test':
     target: 'https://example.com'
     changeOrigin: true
-  '/humanitec':
-    target: 'https://api.humanitec.io'
-    headers:
-      Authorization: Bearer ${HUMANITEC_TOKEN}
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs
@@ -89,4 +85,4 @@ catalog:
 humanitec:
   orgId: the-frontside-software-inc
   registryUrl: "northamerica-northeast1-docker.pkg.dev/frontside-backstage/frontside-artifacts"
-  "proxyPath": "/humanitec"
+  token: ${HUMANITEC_TOKEN}

--- a/packages/backend/src/plugins/humanitec.ts
+++ b/packages/backend/src/plugins/humanitec.ts
@@ -8,6 +8,5 @@ export default async function createPlugin(
   return await createRouter({
     logger: env.logger,
     config: env.config,
-    discovery: env.discovery
   });
 }

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -29,7 +29,7 @@ export default async function createPlugin({
     }),
     createHumanitecApp({
       orgId: config.getString('humanitec.orgId'),
-      api: `${await discovery.getBaseUrl('proxy')}/humanitec`
+      token: config.getString('humanitec.token')
     })
   ];
   return await createRouter({

--- a/plugins/humanitec-backend/package.json
+++ b/plugins/humanitec-backend/package.json
@@ -28,6 +28,7 @@
     "@backstage/plugin-scaffolder-backend": "1.1.0",
     "@types/express": "*",
     "cross-fetch": "3.1.5",
+    "exponential-backoff": "^3.1.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "js-yaml": "^4.1.0",

--- a/plugins/humanitec-backend/src/actions/create-app.ts
+++ b/plugins/humanitec-backend/src/actions/create-app.ts
@@ -6,11 +6,11 @@ import { SetupFileSchema } from '../types/create-app';
 import { createHumanitecClient } from '../clients/humanitec';
 
 interface HumanitecCreateApp {
-  api: string;
   orgId: string;
+  token: string;
 }
 
-export function createHumanitecApp({ api, orgId }: HumanitecCreateApp) {
+export function createHumanitecApp({ token, orgId }: HumanitecCreateApp) {
   return createTemplateAction<{ appId: string; setupFile: string; }>({
     id: 'humanitec:create-app',
     schema: {
@@ -25,7 +25,7 @@ export function createHumanitecApp({ api, orgId }: HumanitecCreateApp) {
       }
     },
     async handler({ logger, input, workspacePath }) {
-      const client = createHumanitecClient({ api, orgId });
+      const client = createHumanitecClient({ orgId, token });
 
       const setupFile = input.setupFile ?? 'humanitec-apps.yaml';
       const setupFilePath = resolve(join(workspacePath, setupFile));

--- a/plugins/humanitec-backend/src/service/standaloneServer.ts
+++ b/plugins/humanitec-backend/src/service/standaloneServer.ts
@@ -36,7 +36,6 @@ export async function startStandaloneServer(
 
   const router = await createRouter({
     config: options.config,
-    discovery: options.discovery,
     logger,
   });
 

--- a/plugins/humanitec/src/components/HumanitecCardComponent.tsx
+++ b/plugins/humanitec/src/components/HumanitecCardComponent.tsx
@@ -10,6 +10,7 @@ import { HumanitecLogoIcon } from './HumanitecLogoIcon';
 import { HUMANITEC_APP_ID_ANNOTATION, HUMANITEC_MISSING_ANNOTATION_ERROR, HUMANITEC_ORG_ID_ANNOTATION } from '../annotations';
 import { HumanitecCardContent } from './HumanitecCardContent';
 import { HumanitecAnnotationsEmptyState } from './HumanitecAnnotationsEmptyState';
+import { HumanitecErrorState } from './HumanitecErrorState';
 
 interface HumanitecCardComponentProps {
 }
@@ -30,6 +31,8 @@ export function HumanitecCardComponent({ }: HumanitecCardComponentProps) {
 
   const classes = useStyles();
 
+  console.log(data)
+
   let content: ReactNode = null;
   if (Array.isArray(data)) {
     content = (
@@ -43,6 +46,8 @@ export function HumanitecCardComponent({ }: HumanitecCardComponentProps) {
     )
   } else if (data instanceof Error && data.message === HUMANITEC_MISSING_ANNOTATION_ERROR) {
     content = (<HumanitecAnnotationsEmptyState />)
+  } else {
+    content = (<HumanitecErrorState error={data} />)
   }
 
   let action: ReactNode = null;

--- a/plugins/humanitec/src/components/HumanitecErrorState.tsx
+++ b/plugins/humanitec/src/components/HumanitecErrorState.tsx
@@ -1,0 +1,6 @@
+import { Typography } from '@material-ui/core';
+import React from 'react';
+
+export function HumanitecErrorState({ error }: { error: Error }) {
+  return <Typography color="error">{error.message}</Typography>
+}

--- a/plugins/humanitec/src/hooks/useAppInfo.ts
+++ b/plugins/humanitec/src/hooks/useAppInfo.ts
@@ -15,14 +15,18 @@ export function useAppInfo({ appId, orgId }: { appId: string; orgId: string }) {
       createUrl().then((url) => {
         source = new EventSource(url);
 
-        source.onmessage = (message) => {
+        source.addEventListener('update-success', (message) => {
           try {
             setData(JSON.parse(message.data));
           } catch (e) {
             // eslint-disable-next-line no-console
             console.error(e);
           }
-        };
+        });
+
+        source.addEventListener('update-failure', (message) => {
+          setData(new Error(message.data))
+        })
       });
     } else {
       setData(new Error(HUMANITEC_MISSING_ANNOTATION_ERROR))

--- a/yarn.lock
+++ b/yarn.lock
@@ -10095,6 +10095,11 @@ expect@^27.5.1:
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
 
+exponential-backoff@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.0.tgz#9409c7e579131f8bd4b32d7d8094a911040f2e68"
+  integrity sha512-oBuz5SYz5zzyuHINoe9ooePwSu0xApKWgeNzok4hZ5YKXFh9zrQBEM15CXqoZkJJPuI2ArvqjPQd8UKJA753XA==
+
 express-promise-router@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/express-promise-router/-/express-promise-router-4.1.1.tgz#8fac102060b9bcc868f84d34fbb12fd8fa494291"


### PR DESCRIPTION
## Motivation

Humanitec API currently has a bug where it occasionally throws a 403 when it can't handle the load.
We don't want these little blips to prevent scaffolding from executing successfully.

## Approach

* Added a retry mechanism and a way to show when an error happens to the frontend.
* Removed the proxy so the calls happen directly to the Humanitec API without flooding our logs