### PR TITLE
Include branch name in Humanitec notification

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,7 +46,7 @@ jobs:
           --header 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
           --header 'Content-Type: application/json' \
           --data-raw '{
-              "branch": "'$GITHUB_BRANCH'",
+              "branch": "'$GITHUB_REF_NAME'",
               "commit": "'$GITHUB_SHA'",
               "image": "'$IMAGE:$TAG'",
               "tags": ["'$TAG'"]


### PR DESCRIPTION
## Motivation

We found that Humanitec is not automatically deploying new images. I wanted to switch it to use latest tag from main branch, but discovered that we weren't actually writing branch name to the notify message.

## Approach

`$GITHUB_BRANCH` is not a real environment variable, use `$GITHUB_REF_NAME` instead.
