### PR TITLE
Changed timeout to 10 seconds and reduced retries

### DIFF
--- a/plugins/humanitec-backend/src/clients/humanitec.ts
+++ b/plugins/humanitec-backend/src/clients/humanitec.ts
@@ -93,6 +93,7 @@ export function createHumanitecClient({ orgId, token }: { token: string; orgId: 
 
       throw new FetchError(`Fetch ${method} to ${url} failed.`, r);
     }, {
+      numOfAttempts: 3,
       // 403 may mean we encountered bug in Humanitec API
       retry: async (e: FetchError) => e.status === 403
     });

--- a/plugins/humanitec-backend/src/service/router.ts
+++ b/plugins/humanitec-backend/src/service/router.ts
@@ -84,7 +84,7 @@ export async function createRouter(
 
     request.on('close', () => clearTimeout(timeout));
 
-    scheduleUpdate(1000);
+    scheduleUpdate(10000);
 
   });
 


### PR DESCRIPTION
## Motivation

The polling mechanism that we use to retrieve data from Humanitec API is very brute force. It puts a lot of pressure on Humanitec service. We really want to be using webhooks. In the mean time, we want to reduce the number of requests to Humanitec API even though it'll make the frontend plugin seem less dynamic.

## Approach

1. Changed the update timeout to 10 seconds2. 
2. Reduced the number of API retries to 3 from 10
