### PR TITLE
Adding codeowners for humanitec plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/plugins/humanitec @thefrontside/humanitec
+/plugins/humanitec-backend @thefrontside/humanitec


### PR DESCRIPTION
## Motivation

We want @Nilsty  to be aware of changes that we're making to Humanitec plugins. 

## Approach

Created codeowners file and added `@thefrontside/humanitec` team as owners of `plugins/humanitec` and `plugins/humanitec-backend`