### PR TITLE
add graphiql plugin and include on sidebar

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,6 +20,7 @@
     "@backstage/plugin-catalog-import": "^0.8.7",
     "@backstage/plugin-catalog-react": "^1.0.1",
     "@backstage/plugin-github-actions": "^0.5.4",
+    "@backstage/plugin-graphiql": "^0.2.37",
     "@backstage/plugin-org": "^0.5.4",
     "@backstage/plugin-scaffolder": "^1.1.0",
     "@backstage/plugin-search": "^0.8.0",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -31,6 +31,7 @@ import { FlatRoutes } from '@backstage/core-app-api';
 import { orgPlugin } from '@backstage/plugin-org';
 import { InspectorPage } from '@frontside/backstage-plugin-effection-inspector';
 import { HumanitecPage } from '@frontside/backstage-plugin-humanitec';
+import { GraphiQLPage } from '@backstage/plugin-graphiql';
 
 const app = createApp({
   apis,
@@ -84,6 +85,7 @@ const routes = (
     <Route path="/settings" element={<UserSettingsPage />} />
     <Route path="/effection-inspector" element={<InspectorPage />}/>
     <Route path="/humanitec" element={<HumanitecPage />}/>
+    <Route path="/graphiql" element={<GraphiQLPage />} />
   </FlatRoutes>
 );
 

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -7,7 +7,13 @@ import {
   AnyApiFactory,
   configApiRef,
   createApiFactory,
+  githubAuthApiRef,
+  errorApiRef,
 } from '@backstage/core-plugin-api';
+import {
+  graphQlBrowseApiRef,
+  GraphQLEndpoints,
+} from '@backstage/plugin-graphiql';
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({
@@ -16,4 +22,23 @@ export const apis: AnyApiFactory[] = [
     factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),
   }),
   ScmAuth.createDefaultApiFactory(),
+  createApiFactory({
+    api: graphQlBrowseApiRef,
+    deps: { errorApi: errorApiRef, githubAuthApi: githubAuthApiRef },
+    factory: ({ errorApi, githubAuthApi }) =>
+      GraphQLEndpoints.from([
+        // example, remove in the future?
+        GraphQLEndpoints.create({
+          id: 'swapi',
+          title: 'Star Wars API',
+          url: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+        }),
+        GraphQLEndpoints.github({
+          id: 'github',
+          title: 'GitHub',
+          errorApi,
+          githubAuthApi,
+        }),
+      ]),
+  }),
 ];

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -27,6 +27,7 @@ import { NavLink } from 'react-router-dom';
 import { Settings as SidebarSettings } from '@backstage/plugin-user-settings';
 import { SidebarSearchModal } from '@backstage/plugin-search'
 import { SearchContextProvider } from '@backstage/plugin-search-react';
+import { GraphiQLIcon } from '@backstage/plugin-graphiql';
 import {
   Sidebar,
   SidebarPage,
@@ -88,6 +89,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarDivider />
       <SidebarScrollWrapper>
         <SidebarItem icon={MapIcon} to="tech-radar" text="Tech Radar" />
+        <SidebarItem icon={GraphiQLIcon} to="graphiql" text="GraphiQL" />
       </SidebarScrollWrapper>
       <SidebarSpace />
       <SidebarDivider />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,6 +1893,22 @@
     react-router-dom "6.0.0-beta.0"
     react-use "^17.2.4"
 
+"@backstage/plugin-graphiql@^0.2.37":
+  version "0.2.37"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-graphiql/-/plugin-graphiql-0.2.37.tgz#a65050fc9aa3a4a4ed55d7df901235eafff895aa"
+  integrity sha512-hojeIKa4ZTVGBku7rtdd7bynWxvgFmKDy8Hzqqoh7SskGw79RZsWv6k0RdhgrkjL8Z9HOkD1H5H6sjIZQGSsUw==
+  dependencies:
+    "@backstage/core-components" "^0.9.4"
+    "@backstage/core-plugin-api" "^1.0.2"
+    "@backstage/theme" "^0.2.15"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    graphiql "^1.5.12"
+    graphql "^16.0.0"
+    graphql-ws "^5.4.1"
+    react-use "^17.2.4"
+
 "@backstage/plugin-org@^0.5.4":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-org/-/plugin-org-0.5.4.tgz#aeb574b2478f0580c0e24e5daab3978ca84c2cac"


### PR DESCRIPTION
## Motivation

Add the graphiql plugin to enable querying from the Backstage app. This can eventually be used to query the graphql backend being enabled in #9.

