### PR TITLE
Add missing build command

### DIFF
--- a/.changeset/famous-pears-dance.md
+++ b/.changeset/famous-pears-dance.md
@@ -1,0 +1,6 @@
+---
+'@frontside/backstage-plugin-humanitec': patch
+'@frontside/backstage-plugin-humanitec-backend': patch
+---
+
+Adding missing dist files from Humanitec bundles

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -14,6 +14,8 @@ jobs:
       with:
         registry-url: https://registry.npmjs.org
     - uses: thefrontside/actions/publish-pr-preview@v2
+      with:
+        INSTALL_SCRIPT: yarn install --frozen-lockfile && yarn tsc && yarn build
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,8 @@ jobs:
       with:
         registry-url: https://registry.npmjs.org
     - uses: thefrontside/actions/synchronize-with-npm@v2
+      with:
+        INSTALL_SCRIPT: yarn install --frozen-lockfile && yarn tsc && yarn build
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

I got someone commenting in Backstage that Humanitec integration was not working.

We are not creating bundles before publishing packages as a result dist files are missing.

## Approach

Make sure that we build files before publishing packages using INSTALL_SCRIPT