### PR TITLE
fix(humanitec-backend): wrong plugin file path

### DIFF
--- a/plugins/humanitec-backend/README.md
+++ b/plugins/humanitec-backend/README.md
@@ -10,7 +10,7 @@
 yarn workspace backend add @frontside/backstage-plugin-humanitec-backend
 ```
 
-2. Create `./packages/backend/plugins/humanitec.ts` with the following content,
+2. Create `./packages/backend/src/plugins/humanitec.ts` with the following content,
 
 ```ts
 import { createRouter } from '@frontside/backstage-plugin-humanitec-backend';


### PR DESCRIPTION
Looks like there was a missing `src/` inside the instructions for installing the backend plugin.

Inside this repository, the plugin is in https://github.com/thefrontside/backstage/blob/main/packages/backend/src/plugins/humanitec.ts
