### PR TITLE
Sort entities from batch loader by using js

### DIFF
--- a/.changeset/tiny-buckets-do.md
+++ b/.changeset/tiny-buckets-do.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-batch-loader': patch
+---
+
+Sort entities by refs by using javascript

--- a/plugins/batch-loader/migrations/20220805125155_init.js
+++ b/plugins/batch-loader/migrations/20220805125155_init.js
@@ -2,17 +2,20 @@ exports.up = async (knex) => {
   const schema = () => knex.schema.withSchema('refs');
 
   await schema().raw(`
-  CREATE VIEW refs.entities as SELECT
-    FORMAT('%s:%s/%s',
-      LOWER(final_entity::json #>> '{kind}'),
-      LOWER(final_entity::json #>> '{metadata, namespace}'),
-      LOWER(final_entity::json #>> '{metadata, name}')) as ref,
-    final_entity FROM public.final_entities;
+  CREATE OR REPLACE FUNCTION entity_to_ref(entity text) RETURNS text AS $$
+    SELECT FORMAT('%s:%s/%s',
+      LOWER(entity::json #>> '{kind}'),
+      LOWER(entity::json #>> '{metadata, namespace}'),
+      LOWER(entity::json #>> '{metadata, name}'));
+  $$ LANGUAGE sql IMMUTABLE;
+
+  CREATE INDEX entity_ref_idx ON final_entities (entity_to_ref(final_entity));
   `);
 };
 
 exports.down = async (knex) => {
   const schema = () => knex.schema.withSchema('refs');
 
-  await schema().dropView('entities');
+  await schema().raw(`DROP INDEX entity_ref_idx;`);
+  await schema().dropFunction('entity_to_ref');
 };

--- a/plugins/batch-loader/migrations/20220805125155_init.js
+++ b/plugins/batch-loader/migrations/20220805125155_init.js
@@ -2,14 +2,6 @@ exports.up = async (knex) => {
   const schema = () => knex.schema.withSchema('refs');
 
   await schema().raw(`
-  CREATE OR REPLACE FUNCTION field(anyelement, VARIADIC anyarray) RETURNS integer AS $$
-    SELECT
-      COALESCE(
-      ( SELECT i FROM generate_subscripts($2, 1) gs(i)
-        WHERE $2[i] = $1 ),
-      0);
-  $$ LANGUAGE SQL;
-
   CREATE VIEW refs.entities as SELECT
     FORMAT('%s:%s/%s',
       LOWER(final_entity::json #>> '{kind}'),
@@ -23,5 +15,4 @@ exports.down = async (knex) => {
   const schema = () => knex.schema.withSchema('refs');
 
   await schema().dropView('entities');
-  await schema().dropFunction('field');
 };

--- a/plugins/batch-loader/src/loader.ts
+++ b/plugins/batch-loader/src/loader.ts
@@ -44,10 +44,11 @@ export class BatchLoader {
     const client = await this.client;
     const stringifiedRefs = refs.map(ref => typeof ref === 'string' ? ref : stringifyEntityRef(ref))
     const rows = await client('refs.entities')
-      .select('final_entity')
-      .whereIn('refs.entities.ref', stringifiedRefs)
-      .orderByRaw(`FIELD(refs.entities.ref, '${stringifiedRefs.join("','")}')`);
-    const entities = rows.map(row => JSON.parse(row.final_entity));
+      .select('*')
+      .whereIn('refs.entities.ref', stringifiedRefs);
+
+    const unsortedEntities = new Map(rows.map(row => [row.ref, JSON.parse(row.final_entity)]));
+    const entities = stringifiedRefs.map(ref => unsortedEntities.get(ref));
     this.logger.info(`Loaded ${entities.length} entities`);
     return entities;
   }

--- a/plugins/batch-loader/src/loader.ts
+++ b/plugins/batch-loader/src/loader.ts
@@ -43,9 +43,10 @@ export class BatchLoader {
     this.logger.info(`Loading entities for refs: ${refs}`);
     const client = await this.client;
     const stringifiedRefs = refs.map(ref => typeof ref === 'string' ? ref : stringifyEntityRef(ref))
-    const rows = await client('refs.entities')
-      .select('*')
-      .whereIn('refs.entities.ref', stringifiedRefs);
+    const rows = await client('public.final_entities')
+      .select('final_entity', client.raw('entity_to_ref(final_entity) as ref'))
+      // NOTE: No overload matches this call. This is a bug in knex.
+      .whereIn(client.raw('entity_to_ref(final_entity)') as unknown as string, stringifiedRefs);
 
     const unsortedEntities = new Map(rows.map(row => [row.ref, JSON.parse(row.final_entity)]));
     const entities = stringifiedRefs.map(ref => unsortedEntities.get(ref));


### PR DESCRIPTION
## Motivation

Postgres variadic function has limitation in 100 arguments, literally you can't pass more than 100 arguments into a postgres function

## Approach

Sort entities by refs by using javascript
