### PR TITLE
Lazy get database client for batch loader

### DIFF
--- a/.changeset/cuddly-baboons-stare.md
+++ b/.changeset/cuddly-baboons-stare.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-batch-loader': patch
+---
+
+Lazy get database client for batch loader


### PR DESCRIPTION
## Motivation

The calling `getClient` has side-effect of creation backstage database. That might lead to an error when batch-loader plugin initialize before catalog plugin. Because catalog plugin creates the db and fails, because db was already created.

## Approach

Add laziness of getting client for batch loader.