### PR TITLE
Modify humanitec modules schema to include variables records

### DIFF
--- a/.changeset/thick-beds-smoke.md
+++ b/.changeset/thick-beds-smoke.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-humanitec-common': minor
+---
+
+Modify modules schema to include variables records

--- a/plugins/humanitec-common/src/types/create-app.ts
+++ b/plugins/humanitec-common/src/types/create-app.ts
@@ -10,8 +10,6 @@ const IngressRule = object({
   type: string()
 });
 
-const Variables = record(string()).optional();
-
 export const Module = object({
   externals: record(object({
     type: string()
@@ -25,7 +23,7 @@ export const Module = object({
         limits: Resource.optional(),
         requests: Resource.optional(),
       }).optional(),
-      variables: Variables,
+      variables: record(string()).optional(),
       volume_mounts: object({}),
       files: object({})
     })).optional(),

--- a/plugins/humanitec-common/src/types/create-app.ts
+++ b/plugins/humanitec-common/src/types/create-app.ts
@@ -25,9 +25,7 @@ export const Module = object({
         limits: Resource.optional(),
         requests: Resource.optional(),
       }).optional(),
-      variables: object({
-        Variables
-      }),
+      variables: Variables,
       volume_mounts: object({}),
       files: object({})
     })).optional(),

--- a/plugins/humanitec-common/src/types/create-app.ts
+++ b/plugins/humanitec-common/src/types/create-app.ts
@@ -10,6 +10,8 @@ const IngressRule = object({
   type: string()
 });
 
+const Variables = record(string()).optional();
+
 export const Module = object({
   externals: record(object({
     type: string()
@@ -23,7 +25,9 @@ export const Module = object({
         limits: Resource.optional(),
         requests: Resource.optional(),
       }).optional(),
-      variables: object({}),
+      variables: object({
+        Variables
+      }),
       volume_mounts: object({}),
       files: object({})
     })).optional(),


### PR DESCRIPTION
## Motivation

Variables are not being included [when the humanitec specs file is parsed](https://github.com/thefrontside/backstage/blob/96a37638e93b014e331a9fd03273c916073c19ce/plugins/humanitec-backend/src/actions/create-app.ts#L41) in the humanitec create-app action for the scaffolder. I think it's because the schema is expecting the variables type to be an [empty object](https://github.com/thefrontside/backstage/blob/96a37638e93b014e331a9fd03273c916073c19ce/plugins/humanitec-common/src/types/create-app.ts#L26).

## Approach

Added variables record to the schema.

## Notes

https://docs.humanitec.com/reference/workload-profiles/profiles/default-module#example