### PR TITLE
customize the executable name and URL

### DIFF
--- a/packages/backend/src/plugins/idp.ts
+++ b/packages/backend/src/plugins/idp.ts
@@ -3,8 +3,14 @@ import { createRouter } from '@frontside/backstage-plugin-platform-backend';
 import { PluginEnvironment } from '../types';
 
 export default async function createPlugin({
+  config,
   logger,
   discovery,
 }: PluginEnvironment): Promise<Router> {
-  return await createRouter({ logger, discovery });
+  return await createRouter({
+    executableName: 'idp',
+    logger,
+    discovery,
+    appURL: `${config.getString('app.baseUrl')}/platform`,
+  });
 }

--- a/plugins/platform-backend/cli/install.sh
+++ b/plugins/platform-backend/cli/install.sh
@@ -1,8 +1,13 @@
-executables_url() {
-    echo "http://localhost:3000/api/idp/executables"
+executable_name() {
+    echo "{{executableName}}"
 }
-download_url() {
-    echo "http://localhost:7007/api/idp/executables/dist"
+
+executables_url() {
+    echo "{{appURL}}"
+}
+
+downloads_url() {
+    echo "{{downloadsURL}}"
 }
 
 info() {
@@ -33,7 +38,7 @@ bold() {
 
 usage() {
     cat >&2 <<END_USAGE
-install.sh: Install idp executables
+install.sh: Install {{executableName}} executables
 
 USAGE:
     install.sh [FLAGS] [OPTIONS]
@@ -92,9 +97,9 @@ download_executable_from_backstage() {
     local os_info="$1"
     local tmpdir="$2"
 
-    local filename="my-idp-$os_info"
+    local filename="$(executable_name)-$os_info"
     local download_file="$tmpdir/$filename"
-    local archive_url="$(download_url)/$filename"
+    local archive_url="$(downloads_url)/$filename"
     curl --progress-bar --show-error --location "$archive_url" --output "$download_file" --write-out '%{filename_effective}'
 }
 
@@ -131,7 +136,7 @@ install_from_file() {
 
     create_tree "$install_dir"
 
-    info 'Extracting' "IDP binaries"
+    info 'Extracting' "$(executable_name) executable..."
     # extract the files to the specified directory
     cp -c "$binfile" "$install_dir"/bin/idp
     chmod a+x "$install_dir"/bin/idp
@@ -146,7 +151,7 @@ install_remote() {
     exit_status="$?"
     if [ "$exit_status" != 0 ]
     then
-        error "Could not download IDP executable. See $(executables_url) for a list of available executables"
+        error "Could not download the $(executable_name) executable. See $(executables_url) for a list of available executables"
         return "$exit_status"
     fi
 
@@ -162,7 +167,7 @@ install() {
     exit 1
   fi
 
-  if [ -e "$install_dir/bin/idp" ]; then
+  if [ -e "$install_dir/bin/$(executable_name)" ]; then
       info "Upgrade" "new executable will overwrite existing version"
   fi
 

--- a/plugins/platform-backend/package.json
+++ b/plugins/platform-backend/package.json
@@ -28,18 +28,23 @@
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
-    "winston": "^3.2.1",
+    "node-deno": "^0.0.2",
     "node-fetch": "^2.6.7",
-    "yn": "^4.0.0",
-    "node-deno": "^0.0.2"
+    "nunjucks": "^3.2.3",
+    "winston": "^3.2.1",
+    "yn": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.17.2",
+    "@types/nunjucks": "^3.2.1",
     "@types/supertest": "^2.0.8",
-    "supertest": "^4.0.2",
-    "msw": "^0.42.0"
+    "msw": "^0.42.0",
+    "supertest": "^4.0.2"
   },
   "files": [
     "dist"
-  ]
+  ],
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/plugins/platform-backend/src/executables.ts
+++ b/plugins/platform-backend/src/executables.ts
@@ -3,7 +3,9 @@ import type { CompilationTarget } from 'node-deno';
 import { CompilationTargets, compile } from 'node-deno';
 import { existsSync } from 'fs';
 
-export type Executables = Record<CompilationTarget, Executable>;
+export interface Executables extends  Record<CompilationTarget, Executable> {
+  executableName: string;
+}
 
 export type Executable = {
   type: 'error';
@@ -24,7 +26,7 @@ export type Executable = {
 }
 
 export interface FindOrCreateOptions {
-  baseURL: string;
+  downloadsURL: string;
   logger: Logger;
   distDir: string;
   executableName: string;
@@ -38,13 +40,13 @@ export function findOrCreateExecutables(options: FindOrCreateOptions): Executabl
       ...executables,
       [target]: findOrCreateExecutable(target, options),
     }
-  }, {}) as Executables;
+  }, { executableName: options.executableName }) as Executables;
 }
 
 function findOrCreateExecutable(target: CompilationTarget, options: FindOrCreateOptions): Executable {
-  let { logger, distDir, executableName, entrypoint, baseURL } = options;
+  let { logger, distDir, executableName, entrypoint, downloadsURL } = options;
   let output = `${distDir}/${executableName}-${target}`;
-  let url = `${baseURL}/${executableName}-${target}`;
+  let url = `${downloadsURL}/${executableName}-${target}`;
 
   let executable: Executable = {
     type: 'compiling',

--- a/plugins/platform/src/components/AllExecutables/AllExecutables.tsx
+++ b/plugins/platform/src/components/AllExecutables/AllExecutables.tsx
@@ -15,7 +15,9 @@ export const DenseTable = ({ executables }: { executables: Executables}) => {
     { title: 'URL', field: 'url' },
   ];
 
-  const data = Object.entries(executables).map(([target, executable]) => {
+  let { executableName, ...binaries } = executables;
+
+  const data = Object.entries(binaries).map(([target, executable]) => {
     return {
       target,
       url: executable.type === 'compiled' ? executable.url : 'N/A',
@@ -25,7 +27,7 @@ export const DenseTable = ({ executables }: { executables: Executables}) => {
 
   return (
     <Table
-      title="Downlead my-idp"
+      title={`${executableName} downloads`}
       options={{ search: false, paging: false }}
       columns={columns}
       data={data}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6584,6 +6584,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/nunjucks@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@types/nunjucks/-/nunjucks-3.2.1.tgz#02a3ade3dc4d3950029c6466a4034565dba7cf8c"
+  integrity sha512-hUh5HIC7peH+0MvlYU5KM2RydWxG1mBceivHsQGwlelU9zlczLICyJmjMwgjkI3m0+N50n46GVHkw35lIim6LQ==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
## Motivation
In order to standup the executable delivery mechanism, we just hard-coded everything to be local development values and a fixed version of the executable name. However, the entire point is that everyone gets their own internal developer platform that is unique to them. We want to be able to customize that experience and also have it work in production environments.

## approach
This adds the `executableName`, and `appURL`  parameter to `createRouter` where you can pass in the specific name that you want your binary package to have. It will then compile it as that executable, and create a unique `install.sh` script using a nunjucks template.
