### PR TITLE
Add basic help and info commands

### DIFF
--- a/plugins/platform-backend/cli/cli.ts
+++ b/plugins/platform-backend/cli/cli.ts
@@ -1,0 +1,31 @@
+import { parse } from "./deps.ts";
+
+const usage = (name: string, description: string) => `
+${name}: ${description}
+
+USAGE:
+  ${name} COMMAND [OPTIONS]
+`;
+
+export interface CLIOptions {
+  name: string;
+  description: string;
+  apiURL: string;
+  args: string[];
+  target: string;
+}
+
+export async function cli(options: CLIOptions) {
+  let { apiURL, description, args, name, target } = options;
+  let flags = parse(args);
+  let [command] = flags._;
+
+  switch (command) {
+    case "help":
+      console.log(usage(name, description))
+      break;
+    default:
+      console.log(`${name}\n${Array(name.length).fill("=").join('')}\narchitecture: ${target}\nbackstage: ${apiURL}`)
+      break;
+  }
+}

--- a/plugins/platform-backend/cli/deno.json
+++ b/plugins/platform-backend/cli/deno.json
@@ -1,0 +1,7 @@
+{
+  "lint": {
+    "rules": {
+      "exclude": ["prefer-const"]
+    }
+  }
+}

--- a/plugins/platform-backend/cli/deps.ts
+++ b/plugins/platform-backend/cli/deps.ts
@@ -1,0 +1,2 @@
+export { parse } from "https://deno.land/std@0.159.0/flags/mod.ts";
+export { assert } from "https://deno.land/std@0.159.0/testing/asserts.ts";

--- a/plugins/platform-backend/cli/main.ts
+++ b/plugins/platform-backend/cli/main.ts
@@ -1,1 +1,16 @@
-console.log('Hello Backstage!');
+import { assert } from "./deps.ts";
+import { cli } from "./cli.ts";
+
+let [name, apiURL, description, ...args] = Deno.args;
+
+assert(name, "compiled incorrectly -  executable name is not defined");
+assert(apiURL, "compiled incorrectly -  backstage platform url is not found");
+assert(description, "compiled incorrectly -  no platform description defined");
+
+await cli({
+  name,
+  description,
+  apiURL,
+  args,
+  target: Deno.build.target,
+}).catch((error) => console.error(error));

--- a/plugins/platform-backend/package.json
+++ b/plugins/platform-backend/package.json
@@ -28,7 +28,7 @@
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
-    "node-deno": "^0.0.2",
+    "node-deno": "^0.0.3",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.3",
     "winston": "^3.2.1",

--- a/plugins/platform-backend/src/executables.ts
+++ b/plugins/platform-backend/src/executables.ts
@@ -26,6 +26,7 @@ export type Executable = {
 }
 
 export interface FindOrCreateOptions {
+  baseURL: string;
   downloadsURL: string;
   logger: Logger;
   distDir: string;
@@ -44,7 +45,7 @@ export function findOrCreateExecutables(options: FindOrCreateOptions): Executabl
 }
 
 function findOrCreateExecutable(target: CompilationTarget, options: FindOrCreateOptions): Executable {
-  let { logger, distDir, executableName, entrypoint, downloadsURL } = options;
+  let { logger, baseURL, distDir, executableName, entrypoint, downloadsURL } = options;
   let output = `${distDir}/${executableName}-${target}`;
   let url = `${downloadsURL}/${executableName}-${target}`;
 
@@ -69,7 +70,14 @@ function findOrCreateExecutable(target: CompilationTarget, options: FindOrCreate
     compile({
       target,
       output,
-      entrypoint,
+      // pass metadata as the first three args of the script
+      entrypoint: [entrypoint, executableName, baseURL, '"internal developer platform"'],
+
+      // only allow network access back to the backstage server
+      allowNet: [baseURL],
+
+      // fail immediately if a permission is not present
+      noPrompt: true,
     }).then(result => {
       let stdio = {
         stdout: result.stdout,

--- a/plugins/platform-backend/src/service/router.ts
+++ b/plugins/platform-backend/src/service/router.ts
@@ -41,6 +41,7 @@ export async function createRouter(
   let executables = findOrCreateExecutables({
     logger,
     distDir: 'dist-bin',
+    baseURL,
     downloadsURL,
     executableName,
     entrypoint: resolvePackagePath("@frontside/backstage-plugin-platform-backend", "cli", "main.ts"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -16785,10 +16785,10 @@ node-cache@^5.1.2:
   dependencies:
     clone "2.x"
 
-node-deno@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/node-deno/-/node-deno-0.0.2.tgz#9ece02a018bb50d0ed6b54c04e4c688fa1c8b314"
-  integrity sha512-uP+ATXzDyfqxzfPR/TPg47n+eCQGYNMJqQs+/mARh2UsQaAn+O7z9yNnkKXqS7rQ2z0Zcg1tzsXYsbCxJeyFxQ==
+node-deno@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/node-deno/-/node-deno-0.0.3.tgz#c2cea2c42ce23daa72bc6fcce7d068c6196febef"
+  integrity sha512-5mJGsLXEsuTgIHiqKjclPbpkUimqRiuQ1eaQ37oxeeh3bmi7O3jP1C4aU4lpnXDrVf3dfnqzqhyjOMSAZpU1nw==
   dependencies:
     "@effection/process" "^2.1.1"
     deno-bin "^1.26.0"


### PR DESCRIPTION
## Motivation
One of the really nice things about having your own developer platform is that we can configure the compiled binary to talk back directly to the server it was downloaded from.

## Approach
To accomplish this, we "statically" pass the executable name, the backend url, and the platform description as arguments to the compilation. That way we can use them not only to generate help and binary info for diagnostic purposes, but we will obviously need the url to connect to the backstage server.

## Screenshots

![demonstration of the platform CLI](https://user-images.githubusercontent.com/4205/194940630-c26a9da4-2c06-4ceb-abd3-e0f79960603f.gif)
