### PR TITLE
Make some improvements to graphql plugin

### DIFF
--- a/.changeset/forty-scissors-sniff.md
+++ b/.changeset/forty-scissors-sniff.md
@@ -1,0 +1,7 @@
+---
+'@frontside/backstage-plugin-graphql': minor
+'backend': patch
+'@frontside/backstage-plugin-batch-loader': patch
+---
+
+Make some improvements to graphql plugin

--- a/packages/backend/src/graphql/my-module.ts
+++ b/packages/backend/src/graphql/my-module.ts
@@ -1,8 +1,9 @@
+import { resolvePackagePath } from '@backstage/backend-common'
 import { createModule, gql } from 'graphql-modules'
 
 export const myModule = createModule({
   id: 'my-module',
-  dirname: __dirname,
+  dirname: resolvePackagePath('backend', 'src/graphql'),
   typeDefs: [
     gql`
       type Query {

--- a/packages/backend/src/plugins/graphql.ts
+++ b/packages/backend/src/plugins/graphql.ts
@@ -9,7 +9,6 @@ export default async function createPlugin(
   return await createRouter({
     modules: [myModule],
     logger: env.logger,
-    catalog: env.catalog,
     databaseManager: env.databaseManager,
   });
 }

--- a/packages/backend/src/plugins/graphql.ts
+++ b/packages/backend/src/plugins/graphql.ts
@@ -10,5 +10,6 @@ export default async function createPlugin(
     modules: [myModule],
     logger: env.logger,
     catalog: env.catalog,
+    databaseManager: env.databaseManager,
   });
 }

--- a/plugins/batch-loader/src/loader.ts
+++ b/plugins/batch-loader/src/loader.ts
@@ -30,7 +30,7 @@ export class BatchLoader {
 
   public async getEntitiesByRefs(
     refs: (string | CompoundEntityRef)[],
-  ): Promise<Entity[]> {
+  ): Promise<(Entity | undefined)[]> {
     this.logger.info(`Loading entities for refs: ${refs}`);
     const client = await this.getClient();
     const stringifiedRefs = refs.map(ref => typeof ref === 'string' ? ref : stringifyEntityRef(ref))

--- a/plugins/batch-loader/src/loader.ts
+++ b/plugins/batch-loader/src/loader.ts
@@ -1,9 +1,5 @@
 import { DatabaseManager } from '@backstage/backend-common';
-import {
-  CompoundEntityRef,
-  Entity,
-  stringifyEntityRef,
-} from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import type { Knex } from 'knex';
 import { Logger } from 'winston';
 
@@ -29,7 +25,7 @@ export class BatchLoader {
   }
 
   public async getEntitiesByRefs(
-    refs: (string | CompoundEntityRef)[],
+    refs: (string | { kind: string; namespace?: string; name: string })[],
   ): Promise<(Entity | undefined)[]> {
     this.logger.info(`Loading entities for refs: ${refs}`);
     const client = await this.getClient();

--- a/plugins/graphql/README.md
+++ b/plugins/graphql/README.md
@@ -80,11 +80,12 @@ You can extend the schema from inside of Backstage Backend by creating a [GraphQ
 3. Create a file for your first GraphQL module called `packages/backend/src/graphql/my-module.ts` with the following content
 
   ```ts
+  import { resolvePackagePath } from '@backstage/backend-common'
   import { createModule, gql } from 'graphql-modules'
 
   export const myModule = createModule({
     id: 'my-module',
-    dirname: __dirname,
+    dirname: resolvePackagePath('backend', 'src/graphql'),
     typeDefs: [
       gql`
         type Query {
@@ -153,7 +154,7 @@ Your `Repository` type will automatically get all of the properties from `Entity
 
 It's convenient to be able to query the Backstage GraphQL API from inside of Backstage App. You can accomplish this by installing the [Backstage GraphiQL Plugin](https://roadie.io/backstage/plugins/graphiQL/) and adding the GraphQL API endpoint to the GraphiQL Plugin API factory.
 
-1. Once you installed `@backstage/plugin-graphiql` plugin [with these instructions](https://roadie.io/backstage/plugins/graphiQL/) 
+1. Once you installed `@backstage/plugin-graphiql` plugin [with these instructions](https://roadie.io/backstage/plugins/graphiQL/)
 2. Modify `packages/app/src/apis.ts` to add your GraphQL API as an endpoint
 
     ```ts
@@ -208,4 +209,3 @@ You might want to show the schema from your GraphQL API in API definition sectio
       allow:
         - host: localhost:7007
   ```
-

--- a/plugins/graphql/README.md
+++ b/plugins/graphql/README.md
@@ -81,7 +81,7 @@ Backstage GraphQL Plugin allows developers to extend the schema provided by the 
 
 You can extend the schema from inside of Backstage Backend by creating a [GraphQL Module](https://www.graphql-modules.com) that you can pass to the GraphQL API plugin's router. Here are step-by-step instructions on how to set up your GraphQL API plugin to provide a custom GraphQL Module.
 
-1. Add `graphql-modules` to your backend packages in `packages/backend` with `yarn add graphql-modules`
+1. Add `graphql-modules` and `@graphql-tools/load-files` to your backend packages in `packages/backend` with `yarn add graphql-modules @graphql-tools/load-files`
 1. Create `packages/backend/src/graphql` directory that will contain your modules
 1. Create a file for your first GraphQL module called `packages/backend/src/graphql/my-module.ts` with the following content
 
@@ -138,7 +138,29 @@ You can extend the schema from inside of Backstage Backend by creating a [GraphQ
 
 1. Start your backend and you should be able to query your API with `{ hello }` query to get `{ data: { hello: 'world' } }`
 
-1. If you use TypeScript and generate types from your GraphQL modules you should create `packages/backend/src/schema.ts` file:
+1. (Optional) You can also extend existing basic node types. For example, you can add a new field to the `Component` interface. Here is what the result should look like.
+
+  ```ts
+  // ./src/graphql/extensions.ts
+  import { resolvePackagePath } from '@backstage/backend-common'
+  import { loadFilesSync } from '@graphql-tools/load-files';
+  import { createModule } from 'graphql-modules'
+
+  export const extensionsModule = createModule({
+    id: 'extensions',
+    dirname: resolvePackagePath('backend', 'src/graphql'),
+    typeDefs: loadFilesSync(resolvePackagePath('backend', 'src/graphql/extensions.graphql')),
+  });
+  ```
+
+  ```graphql
+  # ./src/graphql/extensions.graphql
+  interface Component {
+    type: String @field(at: "spec.type")
+  }
+  ```
+
+1. (Optional) If you use TypeScript and generate types from your GraphQL modules you should create `packages/backend/src/schema.ts` file:
 ```ts
 import { resolvePackagePath } from '@backstage/backend-common';
 import { transformSchema } from '@frontside/backstage-plugin-graphql';

--- a/plugins/graphql/codegen.yml
+++ b/plugins/graphql/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: "src/app/modules/**/*.graphql"
+schema: "src/app/schema.ts"
 documents: null
 generates:
   ./src/app/modules/:

--- a/plugins/graphql/codegen.yml
+++ b/plugins/graphql/codegen.yml
@@ -1,6 +1,5 @@
 overwrite: true
 schema: "src/app/schema.ts"
-documents: null
 generates:
   ./src/app/modules/:
     preset: graphql-modules

--- a/plugins/graphql/package.json
+++ b/plugins/graphql/package.json
@@ -30,6 +30,7 @@
     "@envelop/core": "^2.3.0",
     "@envelop/graphql-modules": "^3.3.0",
     "@graphql-tools/load-files": "^6.5.3",
+    "@graphql-tools/merge": "^8.3.6",
     "@graphql-tools/schema": "^8.3.6",
     "@graphql-tools/utils": "^8.6.5",
     "@types/express": "*",

--- a/plugins/graphql/package.json
+++ b/plugins/graphql/package.json
@@ -30,6 +30,7 @@
     "@backstage/catalog-client": "^1.1.1",
     "@backstage/catalog-model": "^1.1.2",
     "@envelop/core": "^2.3.0",
+    "@envelop/dataloader": "^3.3.2",
     "@envelop/graphql-modules": "^3.3.0",
     "@frontside/backstage-plugin-batch-loader": "^0.2.1",
     "@graphql-tools/load-files": "^6.5.3",

--- a/plugins/graphql/package.json
+++ b/plugins/graphql/package.json
@@ -44,6 +44,7 @@
     "express-graphql": "^0.12.0",
     "express-promise-router": "^4.1.0",
     "graphql-modules": "^2.0.0",
+    "graphql-relay": "^0.10.0",
     "graphql-type-json": "^0.3.2",
     "lodash": "^4.17.21",
     "winston": "^3.2.1"

--- a/plugins/graphql/package.json
+++ b/plugins/graphql/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.15.2",
-    "@backstage/catalog-client": "^1.1.1",
     "@backstage/catalog-model": "^1.1.2",
     "@envelop/core": "^2.3.0",
     "@envelop/dataloader": "^3.3.2",
@@ -50,6 +49,7 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
+    "@backstage/catalog-client": "^1.1.1",
     "@backstage/cli": "^0.20.0",
     "@effection/jest": "^2.0.4",
     "@frontside/graphgen": "^1.7.0",

--- a/plugins/graphql/package.json
+++ b/plugins/graphql/package.json
@@ -22,11 +22,13 @@
     "postpack": "backstage-cli package postpack",
     "clean": "backstage-cli clean"
   },
+  "peerDependencies": {
+    "graphql": ">15.0.0"
+  },
   "dependencies": {
     "@backstage/backend-common": "^0.15.2",
     "@backstage/catalog-client": "^1.1.1",
     "@backstage/catalog-model": "^1.1.2",
-    "@backstage/config": "^1.0.3",
     "@envelop/core": "^2.3.0",
     "@envelop/graphql-modules": "^3.3.0",
     "@graphql-tools/load-files": "^6.5.3",
@@ -39,34 +41,25 @@
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
     "express-promise-router": "^4.1.0",
-    "graphql": "^16.3.0",
     "graphql-modules": "^2.0.0",
-    "graphql-relay": "^0.10.0",
     "graphql-type-json": "^0.3.2",
-    "graphql-ws": "^5.6.4",
     "lodash": "^4.17.21",
-    "winston": "^3.2.1",
-    "yn": "^4.0.0"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "^0.20.0",
     "@effection/jest": "^2.0.4",
-    "@effection/process": "^2.1.2",
-    "@faker-js/faker": "^7.6.0",
     "@frontside/graphgen": "^1.7.0",
     "@frontside/graphgen-backstage": "*",
     "@graphql-codegen/add": "^3.1.1",
-    "@graphql-codegen/cli": "^2.6.2",
-    "@graphql-codegen/graphql-modules-preset": "^2.3.8",
-    "@graphql-codegen/typescript": "^2.4.8",
-    "@graphql-codegen/typescript-resolvers": "^2.6.1",
+    "@graphql-codegen/cli": "^2.11.5",
+    "@graphql-codegen/graphql-modules-preset": "^2.3.14",
+    "@graphql-codegen/typescript": "^2.7.4",
+    "@graphql-codegen/typescript-resolvers": "^2.7.4",
     "@types/graphql": "^14.5.0",
-    "@types/supertest": "^2.0.8",
     "effection": "^2.0.6",
-    "jest": "^29.2.2",
-    "knex": "^2.0.0",
-    "msw": "^0.35.0",
-    "supertest": "^4.0.2"
+    "graphql": "^16.3.0",
+    "jest": "^29.2.2"
   },
   "files": [
     "dist",

--- a/plugins/graphql/package.json
+++ b/plugins/graphql/package.json
@@ -31,6 +31,7 @@
     "@backstage/catalog-model": "^1.1.2",
     "@envelop/core": "^2.3.0",
     "@envelop/graphql-modules": "^3.3.0",
+    "@frontside/backstage-plugin-batch-loader": "^0.2.1",
     "@graphql-tools/load-files": "^6.5.3",
     "@graphql-tools/merge": "^8.3.6",
     "@graphql-tools/schema": "^8.3.6",

--- a/plugins/graphql/src/app/app.ts
+++ b/plugins/graphql/src/app/app.ts
@@ -1,46 +1,44 @@
 import { envelop } from '@envelop/core';
 import { useGraphQLModules } from '@envelop/graphql-modules';
-import { useDataLoader } from '@envelop/dataloader';
 import { Application, createApplication, Module } from 'graphql-modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { Catalog } from './modules/catalog/catalog';
 import { Core } from './modules/core/core';
 import { mappers } from './mappers';
 import { mapSchema } from '@graphql-tools/utils';
+import { EnvelopPlugins } from './types';
+import { useDataLoader } from '@envelop/dataloader';
 import DataLoader from 'dataloader';
-import { Context, EnvelopPlugins } from './types';
 
 export type createGraphQLAppOptions<Plugins extends EnvelopPlugins, Loader extends DataLoader<any, any>> = {
-  loader: (context: Context<Plugins>) => Loader
-  modules: Module[]
-  plugins: Plugins | ((app: Application) => Plugins)
+  modules?: Module[]
+  envelopOptions:
+  | { plugins?: Plugins, loader: () => Loader }
+  | ((app: Application) => { plugins?: Plugins, loader: () => Loader })
 }
 
 export function createGraphQLApp<
   Plugins extends EnvelopPlugins,
   Loader extends DataLoader<any, any>
 >(options: createGraphQLAppOptions<Plugins, Loader>) {
-  const { loader, modules, plugins } = options;
-  const application = create(modules);
-
-  const run = envelop({
-    plugins: [
-      useDataLoader('loader', loader),
-      useGraphQLModules(application),
-      ...Array.isArray(plugins) ? plugins : plugins(application)
-    ],
-  });
-
-  return { run, application };
-}
-
-function create(modules: Module[]) {
-  return createApplication({
+  const { modules, envelopOptions } = options;
+  const application = createApplication({
     schemaBuilder: ({ typeDefs, resolvers }) =>
       mapSchema(
         makeExecutableSchema({ typeDefs, resolvers }),
         mappers
       ),
-    modules: [Core, Catalog, ...modules],
+    modules: [Core, Catalog, ...modules ?? []],
   });
+  const { plugins, loader } = typeof envelopOptions === 'function' ? envelopOptions(application) : envelopOptions;
+
+  const run = envelop({
+    plugins: [
+      useGraphQLModules(application),
+      useDataLoader('loader', loader),
+      ...plugins ?? []
+    ],
+  });
+
+  return { run, application };
 }

--- a/plugins/graphql/src/app/app.ts
+++ b/plugins/graphql/src/app/app.ts
@@ -1,6 +1,7 @@
 import type { CatalogApi, Loader } from './types';
 import { envelop, useExtendContext } from '@envelop/core';
 import { useGraphQLModules } from '@envelop/graphql-modules';
+import { useDataLoader } from '@envelop/dataloader';
 import { createApplication, Module } from 'graphql-modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { Catalog } from './modules/catalog/catalog';
@@ -13,8 +14,8 @@ export { transformSchema } from './transform';
 export type createGraphQLAppOptions = {
   catalog: CatalogApi;
   modules: Module[]
-  loader: Loader;
   plugins: Parameters<typeof envelop>[0]['plugins']
+  loader: () => Loader
 }
 
 export function createGraphQLApp(options: createGraphQLAppOptions) {
@@ -22,7 +23,8 @@ export function createGraphQLApp(options: createGraphQLAppOptions) {
 
   const run = envelop({
     plugins: [
-      useExtendContext(() => ({ catalog: options.catalog, loader: options.loader })),
+      useExtendContext(() => ({ catalog: options.catalog })),
+      useDataLoader('loader', options.loader),
       useGraphQLModules(application),
       ...options.plugins
     ],

--- a/plugins/graphql/src/app/app.ts
+++ b/plugins/graphql/src/app/app.ts
@@ -6,7 +6,10 @@ import { makeExecutableSchema } from '@graphql-tools/schema';
 import { createLoader } from './loaders';
 import { Catalog } from './modules/catalog/catalog';
 import { Core } from './modules/core/core';
-import { transform } from './schema-mapper';
+import { mappers } from './mappers';
+import { mapSchema } from '@graphql-tools/utils';
+
+export { transformSchema } from './transform';
 
 export interface createGraphQLAppOptions {
   catalog: CatalogApi;
@@ -34,9 +37,10 @@ interface CreateOptions {
 function create(options: CreateOptions) {
   return createApplication({
     schemaBuilder: ({ typeDefs, resolvers }) =>
-      transform(makeExecutableSchema({
-        typeDefs, resolvers
-      })),
+      mapSchema(
+        makeExecutableSchema({ typeDefs, resolvers}),
+        mappers
+      ),
     modules: [Core, Catalog, ...options.modules],
   });
 }

--- a/plugins/graphql/src/app/app.ts
+++ b/plugins/graphql/src/app/app.ts
@@ -4,8 +4,7 @@ import { createApplication, Module } from 'graphql-modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { Catalog } from './modules/catalog/catalog';
 import { Core } from './modules/core/core';
-import { mappers } from './mappers';
-import { mapSchema } from '@graphql-tools/utils';
+import { transformDirectives } from './mappers';
 import { EnvelopPlugins } from './types';
 import { useDataLoader } from '@envelop/dataloader';
 import DataLoader from 'dataloader';
@@ -23,9 +22,8 @@ export function createGraphQLApp<
   const { modules, plugins, loader } = options;
   const application = createApplication({
     schemaBuilder: ({ typeDefs, resolvers }) =>
-      mapSchema(
+      transformDirectives(
         makeExecutableSchema({ typeDefs, resolvers }),
-        mappers
       ),
     modules: [Core, Catalog, ...modules ?? []],
   });

--- a/plugins/graphql/src/app/app.ts
+++ b/plugins/graphql/src/app/app.ts
@@ -1,49 +1,46 @@
-import type { CatalogApi, Loader } from './types';
-import { envelop, useExtendContext } from '@envelop/core';
+import { envelop } from '@envelop/core';
 import { useGraphQLModules } from '@envelop/graphql-modules';
 import { useDataLoader } from '@envelop/dataloader';
-import { createApplication, Module } from 'graphql-modules';
+import { Application, createApplication, Module } from 'graphql-modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { Catalog } from './modules/catalog/catalog';
 import { Core } from './modules/core/core';
 import { mappers } from './mappers';
 import { mapSchema } from '@graphql-tools/utils';
+import DataLoader from 'dataloader';
+import { Context, EnvelopPlugins } from './types';
 
-export { transformSchema } from './transform';
-
-export type createGraphQLAppOptions = {
-  catalog: CatalogApi;
+export type createGraphQLAppOptions<Plugins extends EnvelopPlugins, Loader extends DataLoader<any, any>> = {
+  loader: (context: Context<Plugins>) => Loader
   modules: Module[]
-  plugins: Parameters<typeof envelop>[0]['plugins']
-  loader: () => Loader
+  plugins: Plugins | ((app: Application) => Plugins)
 }
 
-export function createGraphQLApp(options: createGraphQLAppOptions) {
-  const application = create(options);
+export function createGraphQLApp<
+  Plugins extends EnvelopPlugins,
+  Loader extends DataLoader<any, any>
+>(options: createGraphQLAppOptions<Plugins, Loader>) {
+  const { loader, modules, plugins } = options;
+  const application = create(modules);
 
   const run = envelop({
     plugins: [
-      useExtendContext(() => ({ catalog: options.catalog })),
-      useDataLoader('loader', options.loader),
+      useDataLoader('loader', loader),
       useGraphQLModules(application),
-      ...options.plugins
+      ...Array.isArray(plugins) ? plugins : plugins(application)
     ],
   });
 
   return { run, application };
 }
 
-interface CreateOptions {
-  modules: Module[]
-}
-
-function create(options: CreateOptions) {
+function create(modules: Module[]) {
   return createApplication({
     schemaBuilder: ({ typeDefs, resolvers }) =>
       mapSchema(
         makeExecutableSchema({ typeDefs, resolvers }),
         mappers
       ),
-    modules: [Core, Catalog, ...options.modules],
+    modules: [Core, Catalog, ...modules],
   });
 }

--- a/plugins/graphql/src/app/app.ts
+++ b/plugins/graphql/src/app/app.ts
@@ -1,6 +1,6 @@
 import { envelop } from '@envelop/core';
 import { useGraphQLModules } from '@envelop/graphql-modules';
-import { Application, createApplication, Module } from 'graphql-modules';
+import { createApplication, Module } from 'graphql-modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { Catalog } from './modules/catalog/catalog';
 import { Core } from './modules/core/core';
@@ -11,17 +11,16 @@ import { useDataLoader } from '@envelop/dataloader';
 import DataLoader from 'dataloader';
 
 export type createGraphQLAppOptions<Plugins extends EnvelopPlugins, Loader extends DataLoader<any, any>> = {
+  loader: () => Loader
+  plugins?: Plugins,
   modules?: Module[]
-  envelopOptions:
-  | { plugins?: Plugins, loader: () => Loader }
-  | ((app: Application) => { plugins?: Plugins, loader: () => Loader })
 }
 
 export function createGraphQLApp<
   Plugins extends EnvelopPlugins,
   Loader extends DataLoader<any, any>
 >(options: createGraphQLAppOptions<Plugins, Loader>) {
-  const { modules, envelopOptions } = options;
+  const { modules, plugins, loader } = options;
   const application = createApplication({
     schemaBuilder: ({ typeDefs, resolvers }) =>
       mapSchema(
@@ -30,7 +29,6 @@ export function createGraphQLApp<
       ),
     modules: [Core, Catalog, ...modules ?? []],
   });
-  const { plugins, loader } = typeof envelopOptions === 'function' ? envelopOptions(application) : envelopOptions;
 
   const run = envelop({
     plugins: [

--- a/plugins/graphql/src/app/index.ts
+++ b/plugins/graphql/src/app/index.ts
@@ -3,28 +3,34 @@ import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
 import { graphqlHTTP } from 'express-graphql';
+import { BatchLoaderOptions } from '@frontside/backstage-plugin-batch-loader';
 import { CatalogClient } from '@backstage/catalog-client';
 import { printSchema } from 'graphql';
 import type { Module } from 'graphql-modules';
+import { createGraphQLApp, createGraphQLAppOptions } from './app';
+import { Loader } from './types';
+import { createLoader } from './loaders';
 
-export interface RouterOptions {
+export * from './app';
+
+export type RouterOptions = {
   logger: Logger;
   catalog: CatalogClient;
   modules?: Module[]
-}
-
-import { createGraphQLApp } from './app';
-
-export * from './app';
+  plugins?: createGraphQLAppOptions['plugins']
+} & ({ loader: Loader } | BatchLoaderOptions);
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const { logger } = options;
+  const loader = 'loader' in options ? options.loader : createLoader(options)
 
-  const { run, application } = createGraphQLApp({ 
-    catalog: options.catalog, 
-    modules: options.modules ?? []
+  const { run, application } = createGraphQLApp({
+    catalog: options.catalog,
+    modules: options.modules ?? [],
+    plugins: options.plugins ?? [],
+    loader,
   });
 
   const router = Router();
@@ -38,7 +44,7 @@ export async function createRouter(
     response.send(printSchema(application.schema))
   });
 
-  router.use('/',  graphqlHTTP(async () => {
+  router.use('/', graphqlHTTP(async () => {
     const { parse, validate, contextFactory, execute } = run();
     return {
       schema: application.schema,

--- a/plugins/graphql/src/app/index.ts
+++ b/plugins/graphql/src/app/index.ts
@@ -8,6 +8,7 @@ import type { Module } from 'graphql-modules';
 import { createGraphQLApp } from './app';
 import { createLoader } from './loaders';
 import type { EnvelopPlugins } from './types';
+import { BatchLoader } from '@frontside/backstage-plugin-batch-loader';
 
 export * from './app';
 export * from './loaders';
@@ -25,10 +26,11 @@ export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const { logger } = options;
+  const batchLoader = new BatchLoader(options)
 
   const { run, application } = createGraphQLApp({
     modules: options.modules,
-    loader: () => createLoader(options),
+    loader: () => createLoader(batchLoader),
     plugins: options.plugins,
   });
 

--- a/plugins/graphql/src/app/index.ts
+++ b/plugins/graphql/src/app/index.ts
@@ -27,9 +27,8 @@ export async function createRouter(
   const { logger } = options;
 
   const { run, application } = createGraphQLApp({
-    loader: () => createLoader(options),
-    modules: options.modules ?? [],
-    plugins: options.plugins ?? [],
+    modules: options.modules,
+    envelopOptions: { loader: () => createLoader(options), plugins: options.plugins }
   });
 
   const router = Router();

--- a/plugins/graphql/src/app/index.ts
+++ b/plugins/graphql/src/app/index.ts
@@ -28,7 +28,8 @@ export async function createRouter(
 
   const { run, application } = createGraphQLApp({
     modules: options.modules,
-    envelopOptions: { loader: () => createLoader(options), plugins: options.plugins }
+    loader: () => createLoader(options),
+    plugins: options.plugins,
   });
 
   const router = Router();

--- a/plugins/graphql/src/app/index.ts
+++ b/plugins/graphql/src/app/index.ts
@@ -1,36 +1,36 @@
-import { errorHandler } from '@backstage/backend-common';
+import { DatabaseManager, errorHandler } from '@backstage/backend-common';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
 import { graphqlHTTP } from 'express-graphql';
-import { BatchLoaderOptions } from '@frontside/backstage-plugin-batch-loader';
 import { CatalogClient } from '@backstage/catalog-client';
 import { printSchema } from 'graphql';
 import type { Module } from 'graphql-modules';
 import { createGraphQLApp, createGraphQLAppOptions } from './app';
-import { Loader } from './types';
 import { createLoader } from './loaders';
 
 export * from './app';
+export * from './loaders';
+export type { Loader } from './types';
 
 export type RouterOptions = {
   logger: Logger;
   catalog: CatalogClient;
+  databaseManager: DatabaseManager;
   modules?: Module[]
   plugins?: createGraphQLAppOptions['plugins']
-} & ({ loader: Loader } | BatchLoaderOptions);
+};
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const { logger } = options;
-  const loader = 'loader' in options ? options.loader : createLoader(options)
 
   const { run, application } = createGraphQLApp({
+    loader: () => createLoader(options),
     catalog: options.catalog,
     modules: options.modules ?? [],
     plugins: options.plugins ?? [],
-    loader,
   });
 
   const router = Router();

--- a/plugins/graphql/src/app/index.ts
+++ b/plugins/graphql/src/app/index.ts
@@ -3,22 +3,22 @@ import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
 import { graphqlHTTP } from 'express-graphql';
-import { CatalogClient } from '@backstage/catalog-client';
 import { printSchema } from 'graphql';
 import type { Module } from 'graphql-modules';
-import { createGraphQLApp, createGraphQLAppOptions } from './app';
+import { createGraphQLApp } from './app';
 import { createLoader } from './loaders';
+import type { EnvelopPlugins } from './types';
 
 export * from './app';
 export * from './loaders';
-export type { Loader } from './types';
+export type { Loader as EntityLoader } from './types';
+export { transformSchema } from './transform';
 
 export type RouterOptions = {
   logger: Logger;
-  catalog: CatalogClient;
   databaseManager: DatabaseManager;
   modules?: Module[]
-  plugins?: createGraphQLAppOptions['plugins']
+  plugins?: EnvelopPlugins
 };
 
 export async function createRouter(
@@ -28,7 +28,6 @@ export async function createRouter(
 
   const { run, application } = createGraphQLApp({
     loader: () => createLoader(options),
-    catalog: options.catalog,
     modules: options.modules ?? [],
     plugins: options.plugins ?? [],
   });

--- a/plugins/graphql/src/app/loaders.ts
+++ b/plugins/graphql/src/app/loaders.ts
@@ -1,13 +1,10 @@
 import type { EntityRef, Loader } from './types';
-import { Entity } from '@backstage/catalog-model';
+import type { Entity } from '@backstage/catalog-model';
 import DataLoader from 'dataloader';
 import { EnvelopError } from '@envelop/core';
-import { BatchLoader, BatchLoaderOptions } from '@frontside/backstage-plugin-batch-loader';
+import type { BatchLoader } from '@frontside/backstage-plugin-batch-loader';
 
-export type LoaderOptions = BatchLoaderOptions
-
-export function createLoader(options: BatchLoaderOptions): Loader {
-  const loader = new BatchLoader(options)
+export function createLoader(loader: Pick<BatchLoader,'getEntitiesByRefs'>): Loader {
   return new DataLoader<EntityRef, Entity>(async (refs): Promise<Array<Entity | Error>> => {
     const entities = await loader.getEntitiesByRefs(refs as EntityRef[])
     return entities.map((entity, index) => entity ?? new EnvelopError(`no such node with ref: '${refs[index]}'`));

--- a/plugins/graphql/src/app/loaders.ts
+++ b/plugins/graphql/src/app/loaders.ts
@@ -1,17 +1,15 @@
-import type { CatalogApi, EntityRef, Loader } from './types';
+import type { EntityRef, Loader } from './types';
 import { Entity } from '@backstage/catalog-model';
 import DataLoader from 'dataloader';
 import { EnvelopError } from '@envelop/core';
+import { BatchLoader, BatchLoaderOptions } from '@frontside/backstage-plugin-batch-loader';
 
-export interface LoaderOptions {
-  catalog: CatalogApi;
-}
+export type LoaderOptions = BatchLoaderOptions
 
-export function createLoader({ catalog }: LoaderOptions): Loader {
-  return new DataLoader<EntityRef, Entity>(function fetch(refs): Promise<Array<Entity | Error>> {
-    return Promise.all(refs.map(async ref => {
-      let entity = await catalog.getEntityByRef(ref);
-      return entity ?? new EnvelopError(`no such node with ref: '${ref}'`);
-    }));
+export function createLoader(options: BatchLoaderOptions): Loader {
+  const loader = new BatchLoader(options)
+  return new DataLoader<EntityRef, Entity>(async (refs): Promise<Array<Entity | Error>> => {
+    const entities = await loader.getEntitiesByRefs(refs as EntityRef[])
+    return entities.map((entity, index) => entity ?? new EnvelopError(`no such node with ref: '${refs[index]}'`));
   });
 }

--- a/plugins/graphql/src/app/mappers.ts
+++ b/plugins/graphql/src/app/mappers.ts
@@ -2,7 +2,6 @@ import type { ResolverContext } from './types';
 
 import { parseEntityRef } from '@backstage/catalog-model';
 import {
-  mapSchema,
   getDirective,
   MapperKind,
   SchemaMapper,
@@ -65,7 +64,7 @@ const resolveMappers: Array<(
   },
 ]
 
-const objectMapper: SchemaMapper = {
+export const mappers: SchemaMapper = {
   [MapperKind.OBJECT_TYPE]: (objectType, schema) => {
     const interfaces = traverseExtends(objectType, schema)
     const typeConfig = objectType.toConfig()
@@ -113,7 +112,3 @@ function traverseExtends(type: GraphQLObjectType | GraphQLInterfaceType, schema:
   }
   return isInterfaceType(type) ? [...interfaces, type] : interfaces
 }
-
-export const transform = (schema: GraphQLSchema) => {
-  return mapSchema(schema, objectMapper)
-};

--- a/plugins/graphql/src/app/mappers.ts
+++ b/plugins/graphql/src/app/mappers.ts
@@ -101,7 +101,7 @@ export const mappers: SchemaMapper = {
 
 function traverseExtends(type: GraphQLObjectType | GraphQLInterfaceType, schema: GraphQLSchema): GraphQLInterfaceType[] {
   const extendDirective = getDirective(schema, type, 'extend')?.[0];
-  const interfaces = []
+  const interfaces = [...type.getInterfaces()]
   if (extendDirective) {
     const extendType = schema.getType(extendDirective.type)
     if (!isInterfaceType(extendType)) {

--- a/plugins/graphql/src/app/mappers.ts
+++ b/plugins/graphql/src/app/mappers.ts
@@ -44,11 +44,9 @@ const resolveMappers: Record<'field' | 'relation', (
     field.resolve = async ({ id }, _, { loader }) => {
       const entity = await loader.load(id);
       if (!entity) return null;
-      // TODO Support arrays in graphql schema
       return get(entity, directive.at);
     };
   },
-  // TODO Support indirect relations `path: Path` `union Path = String | [Path]`
   relation: (field, fieldName, directive, schema) => {
     const fieldType = field.type;
     if (

--- a/plugins/graphql/src/app/mappers.ts
+++ b/plugins/graphql/src/app/mappers.ts
@@ -25,13 +25,13 @@ const resolveMappers: Array<(
   schema: GraphQLSchema
 ) => void> = [
   (objectField, interfaceField, schema) => {
-    const fieldDirective = getDirective(schema, interfaceField ?? objectField, 'field')?.[0];
+    const field = objectField ?? interfaceField
+    const fieldDirective = getDirective(schema, field, 'field')?.[0];
     if (!fieldDirective) return
 
-    const fieldType = (interfaceField ?? objectField).type
-    const isKeyValuePairs = fieldType instanceof GraphQLList
-      && fieldType.ofType instanceof GraphQLObjectType
-      && fieldType.ofType.name === 'KeyValuePair'
+    const isKeyValuePairs = field.type instanceof GraphQLList
+      && field.type.ofType instanceof GraphQLObjectType
+      && field.type.ofType.name === 'KeyValuePair'
     objectField.resolve = async ({ id }, _, { loader }) => {
       const entity = await loader.load(id);
       if (!entity) return null;
@@ -40,12 +40,12 @@ const resolveMappers: Array<(
     };
   },
   (objectField, interfaceField, schema) => {
-    const fieldDirective = getDirective(schema, interfaceField ?? objectField, 'relation')?.[0];
+    const field = objectField ?? interfaceField
+    const fieldDirective = getDirective(schema, field, 'relation')?.[0];
     if (!fieldDirective) return
 
-    const fieldType = (interfaceField ?? objectField).type
-    const isList = fieldType instanceof GraphQLList
-      || (fieldType instanceof GraphQLNonNull && fieldType.ofType instanceof GraphQLList)
+    const isList = field.type instanceof GraphQLList
+      || (field.type instanceof GraphQLNonNull && field.type.ofType instanceof GraphQLList)
     objectField.resolve = async ({ id }, _, { loader }) => {
       const entities = (await loader.load(id))
         ?.relations

--- a/plugins/graphql/src/app/modules/catalog/catalog.graphql
+++ b/plugins/graphql/src/app/modules/catalog/catalog.graphql
@@ -26,13 +26,13 @@ type EntityLink {
   icon: String
 }
 
-type Location @extend(type: "Entity") {
+interface Location @extend(type: "Entity") {
   type: String @field(at: "spec.type")
   target: String @field(at: "spec.target")
   targets: [String] @field(at: "spec.targets")
 }
 
-type API @extend(type: "Entity") {
+interface API @extend(type: "Entity") {
   lifecycle: Lifecycle! @field(at: "spec.lifecycle")
   owner: Owner! @relation(name: "ownedBy")
   definition: String! @field(at: "spec.definition")
@@ -41,7 +41,7 @@ type API @extend(type: "Entity") {
   providers: Connection @relation(name: "apiProvidedBy", type: "Component")
 }
 
-type Component @extend(type: "Entity") {
+interface Component @extend(type: "Entity") {
   lifecycle: Lifecycle! @field(at: "spec.lifecycle")
   owner: Owner! @relation(name: "ownedBy")
   system: System @relation(name: "partOf", kind: "system")
@@ -52,19 +52,19 @@ type Component @extend(type: "Entity") {
   dependencies: Connection @relation(name: "dependsOn", type: "Dependency")
 }
 
-type Domain @extend(type: "Entity") {
+interface Domain @extend(type: "Entity") {
   owner: Owner! @relation(name: "ownedBy")
   systems: Connection @relation(name: "hasPart", type: "System")
 }
 
-type Resource @extend(type: "Entity") {
+interface Resource @extend(type: "Entity") {
   owner: Owner! @relation(name: "ownedBy")
   dependencies: Connection @relation(name: "dependsOn", type: "Dependency")
   dependents: Connection @relation(name: "dependencyOf", type: "Dependency")
   system: System @relation(name: "partOf")
 }
 
-type System @extend(type: "Entity") {
+interface System @extend(type: "Entity") {
   owner: Owner! @relation(name: "ownedBy")
   domain: Domain @relation(name: "partOf")
   components: Connection @relation(name: "hasPart", type: "Component", kind: "component")
@@ -79,14 +79,14 @@ type Step {
   if: JSON
 }
 
-type Template @extend(type: "Entity") {
+interface Template @extend(type: "Entity") {
   parameters: JSONObject @field(at: "spec.parameters")
   steps: [Step]! @field(at: "spec.steps")
   output: JSONObject @field(at: "spec.output")
   owner: Owner @relation(name: "ownedBy")
 }
 
-type Group @extend(type: "Entity") {
+interface Group @extend(type: "Entity") {
   displayName: String @field(at: "spec.profile.displayName")
   email: String @field(at: "spec.profile.email")
   picture: String @field(at: "spec.profile.picture")
@@ -96,7 +96,7 @@ type Group @extend(type: "Entity") {
   ownerOf: Connection @relation(type: "Ownable")
 }
 
-type User @extend(type: "Entity") {
+interface User @extend(type: "Entity") {
   displayName: String @field(at: "spec.profile.displayName")
   email: String @field(at: "spec.profile.email")
   picture: String @field(at: "spec.profile.picture")

--- a/plugins/graphql/src/app/modules/catalog/catalog.graphql
+++ b/plugins/graphql/src/app/modules/catalog/catalog.graphql
@@ -26,13 +26,13 @@ type EntityLink {
   icon: String
 }
 
-interface Location @extend(type: "Entity") {
+interface Location @extend(type: "Entity", when: "kind", is: "Location") {
   type: String @field(at: "spec.type")
   target: String @field(at: "spec.target")
   targets: [String] @field(at: "spec.targets")
 }
 
-interface API @extend(type: "Entity") {
+interface API @extend(type: "Entity", when: "kind", is: "API") {
   lifecycle: Lifecycle! @field(at: "spec.lifecycle")
   owner: Owner! @relation(name: "ownedBy")
   definition: String! @field(at: "spec.definition")
@@ -41,7 +41,7 @@ interface API @extend(type: "Entity") {
   providers: Connection @relation(name: "apiProvidedBy", type: "Component")
 }
 
-interface Component @extend(type: "Entity") {
+interface Component @extend(type: "Entity", when: "kind", is: "Component") {
   lifecycle: Lifecycle! @field(at: "spec.lifecycle")
   owner: Owner! @relation(name: "ownedBy")
   system: System @relation(name: "partOf", kind: "system")
@@ -52,19 +52,19 @@ interface Component @extend(type: "Entity") {
   dependencies: Connection @relation(name: "dependsOn", type: "Dependency")
 }
 
-interface Domain @extend(type: "Entity") {
+interface Domain @extend(type: "Entity", when: "kind", is: "Domain") {
   owner: Owner! @relation(name: "ownedBy")
   systems: Connection @relation(name: "hasPart", type: "System")
 }
 
-interface Resource @extend(type: "Entity") {
+interface Resource @extend(type: "Entity", when: "kind", is: "Resource") {
   owner: Owner! @relation(name: "ownedBy")
   dependencies: Connection @relation(name: "dependsOn", type: "Dependency")
   dependents: Connection @relation(name: "dependencyOf", type: "Dependency")
   system: System @relation(name: "partOf")
 }
 
-interface System @extend(type: "Entity") {
+interface System @extend(type: "Entity", when: "kind", is: "System") {
   owner: Owner! @relation(name: "ownedBy")
   domain: Domain @relation(name: "partOf")
   components: Connection @relation(name: "hasPart", type: "Component", kind: "component")
@@ -79,14 +79,14 @@ type Step {
   if: JSON
 }
 
-interface Template @extend(type: "Entity") {
+interface Template @extend(type: "Entity", when: "kind", is: "Template") {
   parameters: JSONObject @field(at: "spec.parameters")
   steps: [Step]! @field(at: "spec.steps")
   output: JSONObject @field(at: "spec.output")
   owner: Owner @relation(name: "ownedBy")
 }
 
-interface Group @extend(type: "Entity") {
+interface Group @extend(type: "Entity", when: "kind", is: "Group") {
   displayName: String @field(at: "spec.profile.displayName")
   email: String @field(at: "spec.profile.email")
   picture: String @field(at: "spec.profile.picture")
@@ -96,7 +96,7 @@ interface Group @extend(type: "Entity") {
   ownerOf: Connection @relation(type: "Ownable")
 }
 
-interface User @extend(type: "Entity") {
+interface User @extend(type: "Entity", when: "kind", is: "User") {
   displayName: String @field(at: "spec.profile.displayName")
   email: String @field(at: "spec.profile.email")
   picture: String @field(at: "spec.profile.picture")

--- a/plugins/graphql/src/app/modules/catalog/catalog.graphql
+++ b/plugins/graphql/src/app/modules/catalog/catalog.graphql
@@ -11,7 +11,7 @@ union Ownable = API | Component | Domain | Resource | System | Template
 union Dependency = Component | Resource
 union Owner = User | Group
 
-interface Entity @extend(type: "Node") {
+interface Entity @extend(interface: "Node") {
   name: String! @field(at: "metadata.name")
   namespace: String @field(at: "metadata.namespace")
   title: String @field(at: "metadata.title")
@@ -26,49 +26,49 @@ type EntityLink {
   icon: String
 }
 
-interface Location @extend(type: "Entity", when: "kind", is: "Location") {
+interface Location @extend(interface: "Entity", when: "kind", is: "Location") {
   type: String @field(at: "spec.type")
   target: String @field(at: "spec.target")
   targets: [String] @field(at: "spec.targets")
 }
 
-interface API @extend(type: "Entity", when: "kind", is: "API") {
+interface API @extend(interface: "Entity", when: "kind", is: "API") {
   lifecycle: Lifecycle! @field(at: "spec.lifecycle")
-  owner: Owner! @relation(name: "ownedBy")
+  owner: Owner! @relation(type: "ownedBy")
   definition: String! @field(at: "spec.definition")
-  system: System @relation(name: "partOf")
-  consumers: Connection @relation(name: "apiConsumedBy", type: "Component")
-  providers: Connection @relation(name: "apiProvidedBy", type: "Component")
+  system: System @relation(type: "partOf")
+  consumers: Connection @relation(type: "apiConsumedBy", interface: "Component")
+  providers: Connection @relation(type: "apiProvidedBy", interface: "Component")
 }
 
-interface Component @extend(type: "Entity", when: "kind", is: "Component") {
+interface Component @extend(interface: "Entity", when: "kind", is: "Component") {
   lifecycle: Lifecycle! @field(at: "spec.lifecycle")
-  owner: Owner! @relation(name: "ownedBy")
-  system: System @relation(name: "partOf", kind: "system")
-  component: Component @relation(name: "partOf", kind: "component")
-  subComponents: Connection @relation(name: "hasPart", type: "Component")
-  providesApi: Connection @relation(type: "API")
-  consumesApi: Connection @relation(type: "API")
-  dependencies: Connection @relation(name: "dependsOn", type: "Dependency")
+  owner: Owner! @relation(type: "ownedBy")
+  system: System @relation(type: "partOf", kind: "system")
+  component: Component @relation(type: "partOf", kind: "component")
+  subComponents: Connection @relation(type: "hasPart", interface: "Component")
+  providesApi: Connection @relation(interface: "API")
+  consumesApi: Connection @relation(interface: "API")
+  dependencies: Connection @relation(type: "dependsOn", interface: "Dependency")
 }
 
-interface Domain @extend(type: "Entity", when: "kind", is: "Domain") {
-  owner: Owner! @relation(name: "ownedBy")
-  systems: Connection @relation(name: "hasPart", type: "System")
+interface Domain @extend(interface: "Entity", when: "kind", is: "Domain") {
+  owner: Owner! @relation(type: "ownedBy")
+  systems: Connection @relation(type: "hasPart", interface: "System")
 }
 
-interface Resource @extend(type: "Entity", when: "kind", is: "Resource") {
-  owner: Owner! @relation(name: "ownedBy")
-  dependencies: Connection @relation(name: "dependsOn", type: "Dependency")
-  dependents: Connection @relation(name: "dependencyOf", type: "Dependency")
-  system: System @relation(name: "partOf")
+interface Resource @extend(interface: "Entity", when: "kind", is: "Resource") {
+  owner: Owner! @relation(type: "ownedBy")
+  dependencies: Connection @relation(type: "dependsOn", interface: "Dependency")
+  dependents: Connection @relation(type: "dependencyOf", interface: "Dependency")
+  system: System @relation(type: "partOf")
 }
 
-interface System @extend(type: "Entity", when: "kind", is: "System") {
-  owner: Owner! @relation(name: "ownedBy")
-  domain: Domain @relation(name: "partOf")
-  components: Connection @relation(name: "hasPart", type: "Component", kind: "component")
-  resources: Connection @relation(name: "hasPart", type: "Resource", kind: "resource")
+interface System @extend(interface: "Entity", when: "kind", is: "System") {
+  owner: Owner! @relation(type: "ownedBy")
+  domain: Domain @relation(type: "partOf")
+  components: Connection @relation(type: "hasPart", interface: "Component", kind: "component")
+  resources: Connection @relation(type: "hasPart", interface: "Resource", kind: "resource")
 }
 
 type Step {
@@ -79,29 +79,29 @@ type Step {
   if: JSON
 }
 
-interface Template @extend(type: "Entity", when: "kind", is: "Template") {
+interface Template @extend(interface: "Entity", when: "kind", is: "Template") {
   parameters: JSONObject @field(at: "spec.parameters")
   steps: [Step]! @field(at: "spec.steps")
   output: JSONObject @field(at: "spec.output")
-  owner: Owner @relation(name: "ownedBy")
+  owner: Owner @relation(type: "ownedBy")
 }
 
-interface Group @extend(type: "Entity", when: "kind", is: "Group") {
+interface Group @extend(interface: "Entity", when: "kind", is: "Group") {
   displayName: String @field(at: "spec.profile.displayName")
   email: String @field(at: "spec.profile.email")
   picture: String @field(at: "spec.profile.picture")
-  parent: Group @relation(name: "childOf")
-  children: Connection @relation(name: "parentOf", type: "Group")
-  members: Connection @relation(name: "hasMember", type: "User")
-  ownerOf: Connection @relation(type: "Ownable")
+  parent: Group @relation(type: "childOf")
+  children: Connection @relation(type: "parentOf", interface: "Group")
+  members: Connection @relation(type: "hasMember", interface: "User")
+  ownerOf: Connection @relation(interface: "Ownable")
 }
 
-interface User @extend(type: "Entity", when: "kind", is: "User") {
+interface User @extend(interface: "Entity", when: "kind", is: "User") {
   displayName: String @field(at: "spec.profile.displayName")
   email: String @field(at: "spec.profile.email")
   picture: String @field(at: "spec.profile.picture")
-  memberOf: Connection @relation(type: "Group")
-  ownerOf: Connection @relation(type: "Ownable")
+  memberOf: Connection @relation(interface: "Group")
+  ownerOf: Connection @relation(interface: "Ownable")
 }
 
 extend type Query {

--- a/plugins/graphql/src/app/modules/catalog/catalog.graphql
+++ b/plugins/graphql/src/app/modules/catalog/catalog.graphql
@@ -34,41 +34,41 @@ type Location @extend(type: "Entity") {
 
 type API @extend(type: "Entity") {
   lifecycle: Lifecycle! @field(at: "spec.lifecycle")
-  owner: Owner! @relation(type: "ownedBy")
+  owner: Owner! @relation(name: "ownedBy")
   definition: String! @field(at: "spec.definition")
-  system: System @relation(type: "partOf")
-  consumers: [Component] @relation(type: "apiConsumedBy")
-  providers: [Component] @relation(type: "apiProvidedBy")
+  system: System @relation(name: "partOf")
+  consumers: Connection @relation(name: "apiConsumedBy", type: "Component")
+  providers: Connection @relation(name: "apiProvidedBy", type: "Component")
 }
 
 type Component @extend(type: "Entity") {
   lifecycle: Lifecycle! @field(at: "spec.lifecycle")
-  owner: Owner! @relation(type: "ownedBy")
-  system: System @relation(type: "partOf", kind: "system")
-  component: Component @relation(type: "partOf", kind: "component")
-  subComponents: [Component] @relation(type: "hasPart")
-  providesApi: [API] @relation
-  consumesApi: [API] @relation
-  dependencies: [Dependency] @relation(type: "dependsOn")
+  owner: Owner! @relation(name: "ownedBy")
+  system: System @relation(name: "partOf", kind: "system")
+  component: Component @relation(name: "partOf", kind: "component")
+  subComponents: Connection @relation(name: "hasPart", type: "Component")
+  providesApi: Connection @relation(type: "API")
+  consumesApi: Connection @relation(type: "API")
+  dependencies: Connection @relation(name: "dependsOn", type: "Dependency")
 }
 
 type Domain @extend(type: "Entity") {
-  owner: Owner! @relation(type: "ownedBy")
-  systems: [System] @relation(type: "hasPart")
+  owner: Owner! @relation(name: "ownedBy")
+  systems: Connection @relation(name: "hasPart", type: "System")
 }
 
 type Resource @extend(type: "Entity") {
-  owner: Owner! @relation(type: "ownedBy")
-  dependencies: [Dependency] @relation(type: "dependsOn")
-  dependents: [Dependency] @relation(type: "dependencyOf")
-  system: System @relation(type: "partOf")
+  owner: Owner! @relation(name: "ownedBy")
+  dependencies: Connection @relation(name: "dependsOn", type: "Dependency")
+  dependents: Connection @relation(name: "dependencyOf", type: "Dependency")
+  system: System @relation(name: "partOf")
 }
 
 type System @extend(type: "Entity") {
-  owner: Owner! @relation(type: "ownedBy")
-  domain: Domain @relation(type: "partOf")
-  components: [Component] @relation(type: "hasPart", kind: "component")
-  resources: [Resource] @relation(type: "hasPart", kind: "resource")
+  owner: Owner! @relation(name: "ownedBy")
+  domain: Domain @relation(name: "partOf")
+  components: Connection @relation(name: "hasPart", type: "Component", kind: "component")
+  resources: Connection @relation(name: "hasPart", type: "Resource", kind: "resource")
 }
 
 type Step {
@@ -80,28 +80,28 @@ type Step {
 }
 
 type Template @extend(type: "Entity") {
-  parameters: JSONObject @field(at: "spec.parameters ")
+  parameters: JSONObject @field(at: "spec.parameters")
   steps: [Step]! @field(at: "spec.steps")
   output: JSONObject @field(at: "spec.output")
-  owner: Owner @relation(type: "ownedBy")
+  owner: Owner @relation(name: "ownedBy")
 }
 
 type Group @extend(type: "Entity") {
-  children: [Group]! @relation(type: "parentOf")
   displayName: String @field(at: "spec.profile.displayName")
   email: String @field(at: "spec.profile.email")
   picture: String @field(at: "spec.profile.picture")
-  parent: Group @relation(type: "childOf")
-  members: [User] @relation(type: "hasMember")
-  ownerOf: [Ownable] @relation
+  parent: Group @relation(name: "childOf")
+  children: Connection @relation(name: "parentOf", type: "Group")
+  members: Connection @relation(name: "hasMember", type: "User")
+  ownerOf: Connection @relation(type: "Ownable")
 }
 
 type User @extend(type: "Entity") {
-  memberOf: [Group]! @relation
   displayName: String @field(at: "spec.profile.displayName")
   email: String @field(at: "spec.profile.email")
   picture: String @field(at: "spec.profile.picture")
-  ownerOf: [Ownable] @relation
+  memberOf: Connection @relation(type: "Group")
+  ownerOf: Connection @relation(type: "Ownable")
 }
 
 extend type Query {

--- a/plugins/graphql/src/app/modules/catalog/catalog.ts
+++ b/plugins/graphql/src/app/modules/catalog/catalog.ts
@@ -3,16 +3,14 @@ import { CompoundEntityRef, stringifyEntityRef } from '@backstage/catalog-model'
 import { createModule } from "graphql-modules";
 import { loadFilesSync } from '@graphql-tools/load-files'
 import GraphQLJSON, { GraphQLJSONObject } from "graphql-type-json";
-import { resolveType } from "../../resolver";
 
 export const Catalog = createModule({
   id: 'catalog',
   typeDefs: loadFilesSync(resolvePackagePath('@frontside/backstage-plugin-graphql', 'src/app/modules/catalog/catalog.graphql')),
   resolvers: {
-    Entity: { __resolveType: resolveType },
-    Owner: { __resolveType: resolveType },
-    Ownable: { __resolveType: resolveType },
-    Dependency: { __resolveType: resolveType },
+    Owner: { __resolveType: () => 'Node' },
+    Ownable: { __resolveType: () => 'Node' },
+    Dependency: { __resolveType: () => 'Node' },
     Lifecycle: {
       EXPERIMENTAL: 'experimental',
       PRODUCTION: 'production',

--- a/plugins/graphql/src/app/modules/catalog/catalog.ts
+++ b/plugins/graphql/src/app/modules/catalog/catalog.ts
@@ -8,9 +8,6 @@ export const Catalog = createModule({
   id: 'catalog',
   typeDefs: loadFilesSync(resolvePackagePath('@frontside/backstage-plugin-graphql', 'src/app/modules/catalog/catalog.graphql')),
   resolvers: {
-    Owner: { __resolveType: () => 'Node' },
-    Ownable: { __resolveType: () => 'Node' },
-    Dependency: { __resolveType: () => 'Node' },
     Lifecycle: {
       EXPERIMENTAL: 'experimental',
       PRODUCTION: 'production',

--- a/plugins/graphql/src/app/modules/catalog/catalog.ts
+++ b/plugins/graphql/src/app/modules/catalog/catalog.ts
@@ -1,8 +1,8 @@
 import { resolvePackagePath } from "@backstage/backend-common";
-import { CompoundEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
 import { createModule } from "graphql-modules";
 import { loadFilesSync } from '@graphql-tools/load-files'
 import GraphQLJSON, { GraphQLJSONObject } from "graphql-type-json";
+import { ResolverContext } from "../../types";
 
 export const Catalog = createModule({
   id: 'catalog',
@@ -18,8 +18,9 @@ export const Catalog = createModule({
     Query: {
       entity: (
         _: any,
-        { name, kind, namespace = 'default' }: CompoundEntityRef,
-      ): { id: string } => ({ id: stringifyEntityRef({ name, kind, namespace }) }),
+        { name, kind, namespace }: { name: string; kind: string; namespace?: string },
+        { refToId }: ResolverContext
+      ): { id: string } => ({ id: refToId({ name, kind, namespace }) }),
     }
   },
 })

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,4 +1,4 @@
-directive @field(at: FieldAtArgument!) on FIELD_DEFINITION
+directive @field(at: FieldAtArgument) on FIELD_DEFINITION
 directive @relation(type: String, interface: String, kind: String) on FIELD_DEFINITION
 directive @extend(interface: String, when: ExtendWhenArgument, is: ExtendIsArgument) on INTERFACE
 

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,9 +1,31 @@
 directive @field(at: String!) on FIELD_DEFINITION
-directive @relation(type: String, kind: String) on FIELD_DEFINITION
+directive @relation(name: String, type: String, kind: String) on FIELD_DEFINITION
 directive @extend(type: String!) on OBJECT | INTERFACE
 # TODO Add directive @resolve(by: String!) on OBJECT | INTERFACE
 
 interface Node { id: ID! }
+
+interface Connection {
+  pageInfo: PageInfo!
+  edges: [Edge!]!
+  total: Int
+}
+
+interface PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String!
+  endCursor: String!
+}
+
+interface Edge {
+  cursor: String!
+  node: Node!
+}
+
+type NodeConnection @extend(type: "Connection") { pageInfo: PageInfo! }
+type NodePageInfo @extend(type: "PageInfo") { hasNextPage: Boolean! }
+type NodeEdge @extend(type: "Edge") { node: Node! }
 
 type Query {
   node(id: ID!): Node

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,6 +1,7 @@
 directive @field(at: String!) on FIELD_DEFINITION
 directive @relation(type: String, kind: String) on FIELD_DEFINITION
 directive @extend(type: String!) on OBJECT | INTERFACE
+# TODO Add directive @resolve(by: String!) on OBJECT | INTERFACE
 
 interface Node { id: ID! }
 

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,6 +1,10 @@
-directive @field(at: String!) on FIELD_DEFINITION
+directive @field(at: FieldAtArgument!) on FIELD_DEFINITION
 directive @relation(name: String, type: String, kind: String) on FIELD_DEFINITION
-directive @extend(type: String!) on OBJECT | INTERFACE
+directive @extend(type: String!, when: ExtendWhenArgument, is: ExtendIsArgument) on OBJECT | INTERFACE
+
+scalar FieldAtArgument
+scalar ExtendWhenArgument
+scalar ExtendIsArgument
 
 interface Node { id: ID! }
 

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,6 +1,6 @@
 directive @field(at: FieldAtArgument!) on FIELD_DEFINITION
-directive @relation(name: String, type: String, kind: String) on FIELD_DEFINITION
-directive @extend(type: String, when: ExtendWhenArgument, is: ExtendIsArgument) on INTERFACE
+directive @relation(type: String, interface: String, kind: String) on FIELD_DEFINITION
+directive @extend(interface: String, when: ExtendWhenArgument, is: ExtendIsArgument) on INTERFACE
 
 scalar FieldAtArgument
 scalar ExtendWhenArgument

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,7 +1,6 @@
 directive @field(at: String!) on FIELD_DEFINITION
 directive @relation(name: String, type: String, kind: String) on FIELD_DEFINITION
 directive @extend(type: String!) on OBJECT | INTERFACE
-# TODO Add directive @resolve(by: String!) on OBJECT | INTERFACE
 
 interface Node { id: ID! }
 

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,6 +1,6 @@
 directive @field(at: FieldAtArgument!) on FIELD_DEFINITION
 directive @relation(name: String, type: String, kind: String) on FIELD_DEFINITION
-directive @extend(type: String!, when: ExtendWhenArgument, is: ExtendIsArgument) on OBJECT | INTERFACE
+directive @extend(type: String!, when: ExtendWhenArgument, is: ExtendIsArgument) on INTERFACE
 
 scalar FieldAtArgument
 scalar ExtendWhenArgument
@@ -25,10 +25,6 @@ interface Edge {
   cursor: String!
   node: Node!
 }
-
-type NodeConnection @extend(type: "Connection") { pageInfo: PageInfo! }
-type NodePageInfo @extend(type: "PageInfo") { hasNextPage: Boolean! }
-type NodeEdge @extend(type: "Edge") { node: Node! }
 
 type Query {
   node(id: ID!): Node

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,6 +1,6 @@
 directive @field(at: FieldAtArgument!) on FIELD_DEFINITION
 directive @relation(name: String, type: String, kind: String) on FIELD_DEFINITION
-directive @extend(type: String!, when: ExtendWhenArgument, is: ExtendIsArgument) on INTERFACE
+directive @extend(type: String, when: ExtendWhenArgument, is: ExtendIsArgument) on INTERFACE
 
 scalar FieldAtArgument
 scalar ExtendWhenArgument
@@ -8,20 +8,20 @@ scalar ExtendIsArgument
 
 interface Node { id: ID! }
 
-interface Connection {
+interface Connection @extend {
   pageInfo: PageInfo!
   edges: [Edge!]!
   total: Int
 }
 
-interface PageInfo {
+interface PageInfo @extend {
   hasNextPage: Boolean!
   hasPreviousPage: Boolean!
   startCursor: String!
   endCursor: String!
 }
 
-interface Edge {
+interface Edge @extend {
   cursor: String!
   node: Node!
 }

--- a/plugins/graphql/src/app/modules/core/core.ts
+++ b/plugins/graphql/src/app/modules/core/core.ts
@@ -16,8 +16,9 @@ export const Core = createModule({
         return id;
       },
     },
-    Query: {
-      node: (_: any, { id }: { id: string }): { id: string } => ({ id }),
-    },
+    Connection: { __resolveType: () => 'NodeConnection' },
+    PageInfo: { __resolveType: () => 'NodePageInfo' },
+    Edge: { __resolveType: () => 'NodeEdge' },
+    Query: { node: (_: any, { id }: { id: string }): { id: string } => ({ id }) },
   },
 });

--- a/plugins/graphql/src/app/modules/core/core.ts
+++ b/plugins/graphql/src/app/modules/core/core.ts
@@ -14,9 +14,6 @@ export const Core = createModule({
         return id;
       },
     },
-    Connection: { __resolveType: () => 'ConnectionImpl' },
-    PageInfo: { __resolveType: () => 'PageInfoImpl' },
-    Edge: { __resolveType: () => 'EdgeImpl' },
     Query: { node: (_: any, { id }: { id: string }): { id: string } => ({ id }) },
   },
 });

--- a/plugins/graphql/src/app/modules/core/core.ts
+++ b/plugins/graphql/src/app/modules/core/core.ts
@@ -1,7 +1,6 @@
 import { resolvePackagePath } from '@backstage/backend-common';
 import { loadFilesSync } from '@graphql-tools/load-files';
 import { createModule } from 'graphql-modules';
-import { resolveType } from '../../resolver';
 import type { ResolverContext } from '../../types';
 
 export const Core = createModule({
@@ -9,16 +8,15 @@ export const Core = createModule({
   typeDefs: loadFilesSync(resolvePackagePath('@frontside/backstage-plugin-graphql', 'src/app/modules/core/core.graphql')),
   resolvers: {
     Node: {
-      __resolveType: resolveType,
       id: async ({ id }: { id: string }, _: never, { loader }: ResolverContext): Promise<string | null> => {
         const entity = await loader.load(id);
         if (!entity) return null;
         return id;
       },
     },
-    Connection: { __resolveType: () => 'NodeConnection' },
-    PageInfo: { __resolveType: () => 'NodePageInfo' },
-    Edge: { __resolveType: () => 'NodeEdge' },
+    Connection: { __resolveType: () => 'ConnectionImpl' },
+    PageInfo: { __resolveType: () => 'PageInfoImpl' },
+    Edge: { __resolveType: () => 'EdgeImpl' },
     Query: { node: (_: any, { id }: { id: string }): { id: string } => ({ id }) },
   },
 });

--- a/plugins/graphql/src/app/resolver.ts
+++ b/plugins/graphql/src/app/resolver.ts
@@ -1,7 +1,0 @@
-import type { ResolverContext } from "./types";
-
-export async function resolveType({ id }: { id: string }, { loader }: ResolverContext): Promise<string | null> {
-  const entity = await loader.load(id);
-  if (!entity) return null;
-  return entity.kind
-}

--- a/plugins/graphql/src/app/resolver.ts
+++ b/plugins/graphql/src/app/resolver.ts
@@ -1,6 +1,5 @@
 import type { ResolverContext } from "./types";
 
-// TODO This is default resolver, but for types with `@resolve` directive, it should be replaced with the one from the directive.
 export async function resolveType({ id }: { id: string }, { loader }: ResolverContext): Promise<string | null> {
   const entity = await loader.load(id);
   if (!entity) return null;

--- a/plugins/graphql/src/app/resolver.ts
+++ b/plugins/graphql/src/app/resolver.ts
@@ -1,5 +1,6 @@
 import type { ResolverContext } from "./types";
 
+// TODO This is default resolver, but for types with `@resolve` directive, it should be replaced with the one from the directive.
 export async function resolveType({ id }: { id: string }, { loader }: ResolverContext): Promise<string | null> {
   const entity = await loader.load(id);
   if (!entity) return null;

--- a/plugins/graphql/src/app/schema.ts
+++ b/plugins/graphql/src/app/schema.ts
@@ -1,0 +1,3 @@
+import { transformSchema } from "./transform";
+
+export default transformSchema([]);

--- a/plugins/graphql/src/app/transform.ts
+++ b/plugins/graphql/src/app/transform.ts
@@ -9,13 +9,13 @@ export function transformSchema(source: TypeSource) {
   const schema = transformDirectives(
     buildASTSchema(
       mergeTypeDefs([
+        source,
         loadFilesSync(
           resolvePackagePath(
             '@frontside/backstage-plugin-graphql',
             'src/app/modules/**/*.graphql'
           )
         ),
-        source
       ])
     ),
   );

--- a/plugins/graphql/src/app/transform.ts
+++ b/plugins/graphql/src/app/transform.ts
@@ -1,12 +1,12 @@
 import { resolvePackagePath } from '@backstage/backend-common';
 import { loadFilesSync } from '@graphql-tools/load-files';
 import { mergeTypeDefs } from '@graphql-tools/merge';
-import { mapSchema, TypeSource } from '@graphql-tools/utils';
+import { TypeSource } from '@graphql-tools/utils';
 import { buildASTSchema } from 'graphql';
-import { mappers } from './mappers';
+import { transformDirectives } from './mappers';
 
 export function transformSchema(source: TypeSource) {
-  return mapSchema(
+  return transformDirectives(
     buildASTSchema(
       mergeTypeDefs([
         loadFilesSync(
@@ -18,6 +18,5 @@ export function transformSchema(source: TypeSource) {
         source
       ])
     ),
-    mappers,
   );
 }

--- a/plugins/graphql/src/app/transform.ts
+++ b/plugins/graphql/src/app/transform.ts
@@ -9,13 +9,13 @@ export function transformSchema(source: TypeSource) {
   return mapSchema(
     buildASTSchema(
       mergeTypeDefs([
-        source,
         loadFilesSync(
           resolvePackagePath(
             '@frontside/backstage-plugin-graphql',
             'src/app/modules/**/*.graphql'
           )
-        )
+        ),
+        source
       ])
     ),
     mappers,

--- a/plugins/graphql/src/app/transform.ts
+++ b/plugins/graphql/src/app/transform.ts
@@ -2,11 +2,11 @@ import { resolvePackagePath } from '@backstage/backend-common';
 import { loadFilesSync } from '@graphql-tools/load-files';
 import { mergeTypeDefs } from '@graphql-tools/merge';
 import { TypeSource } from '@graphql-tools/utils';
-import { buildASTSchema } from 'graphql';
+import { buildASTSchema, validateSchema } from 'graphql';
 import { transformDirectives } from './mappers';
 
 export function transformSchema(source: TypeSource) {
-  return transformDirectives(
+  const schema = transformDirectives(
     buildASTSchema(
       mergeTypeDefs([
         loadFilesSync(
@@ -19,4 +19,10 @@ export function transformSchema(source: TypeSource) {
       ])
     ),
   );
+  const errors = validateSchema(schema);
+
+  if (errors.length > 0) {
+    throw new Error(errors.map(e => e.message).join('\n'));
+  }
+  return schema
 }

--- a/plugins/graphql/src/app/transform.ts
+++ b/plugins/graphql/src/app/transform.ts
@@ -1,0 +1,23 @@
+import { resolvePackagePath } from '@backstage/backend-common';
+import { loadFilesSync } from '@graphql-tools/load-files';
+import { mergeTypeDefs } from '@graphql-tools/merge';
+import { mapSchema, TypeSource } from '@graphql-tools/utils';
+import { buildASTSchema } from 'graphql';
+import { mappers } from './mappers';
+
+export function transformSchema(source: TypeSource) {
+  return mapSchema(
+    buildASTSchema(
+      mergeTypeDefs([
+        source,
+        loadFilesSync(
+          resolvePackagePath(
+            '@frontside/backstage-plugin-graphql',
+            'src/app/modules/**/*.graphql'
+          )
+        )
+      ])
+    ),
+    mappers,
+  );
+}

--- a/plugins/graphql/src/app/types.ts
+++ b/plugins/graphql/src/app/types.ts
@@ -1,16 +1,14 @@
-import type { CatalogApi as Client } from '@backstage/catalog-client';
-import type { CompoundEntityRef, Entity } from '@backstage/catalog-model';
+import type { Entity } from '@backstage/catalog-model';
 import { envelop } from '@envelop/core';
 import DataLoader from 'dataloader';
 
-export type EntityRef = string | CompoundEntityRef
+export type EntityRef = string | { kind: string; namespace?: string; name: string }
 
 export type Loader = DataLoader<EntityRef, Entity>;
 
 export interface ResolverContext<TLoader extends DataLoader<any, any> = Loader> {
   loader: TLoader
+  refToId: (ref: EntityRef) => string
 }
-
-export type CatalogApi = Pick<Client, "getEntityByRef">;
 
 export type EnvelopPlugins = Parameters<typeof envelop>[0]['plugins']

--- a/plugins/graphql/src/app/types.ts
+++ b/plugins/graphql/src/app/types.ts
@@ -1,14 +1,24 @@
 import type { CatalogApi as Client } from '@backstage/catalog-client';
 import type { CompoundEntityRef, Entity } from '@backstage/catalog-model';
+import { envelop, Plugin } from '@envelop/core';
 import DataLoader from 'dataloader';
 
 export type EntityRef = string | CompoundEntityRef
 
 export type Loader = DataLoader<EntityRef, Entity>;
 
-export interface ResolverContext {
-  loader: Loader
-  catalog: CatalogApi
+export interface ResolverContext<TLoader extends DataLoader<any, any> = Loader> {
+  loader: TLoader
 }
 
 export type CatalogApi = Pick<Client, "getEntityByRef">;
+
+export type EnvelopPlugins = Parameters<typeof envelop>[0]['plugins']
+
+export type Context<TPlugins extends EnvelopPlugins> = (
+  TPlugins extends Array<infer TPlugin>
+    ? TPlugin extends Plugin<infer TContext>
+      ? TContext
+      : never
+    : never
+);

--- a/plugins/graphql/src/app/types.ts
+++ b/plugins/graphql/src/app/types.ts
@@ -1,6 +1,6 @@
 import type { CatalogApi as Client } from '@backstage/catalog-client';
 import type { CompoundEntityRef, Entity } from '@backstage/catalog-model';
-import { envelop, Plugin } from '@envelop/core';
+import { envelop } from '@envelop/core';
 import DataLoader from 'dataloader';
 
 export type EntityRef = string | CompoundEntityRef
@@ -14,17 +14,3 @@ export interface ResolverContext<TLoader extends DataLoader<any, any> = Loader> 
 export type CatalogApi = Pick<Client, "getEntityByRef">;
 
 export type EnvelopPlugins = Parameters<typeof envelop>[0]['plugins']
-
-type Merge<T> = {
-  [K in T extends any ? keyof T : never]: T extends { [key in K]: infer V }
-  ? V
-  : never
-}
-
-export type Context<TPlugins extends EnvelopPlugins> = Merge<(
-  TPlugins extends Array<infer TPlugin>
-    ? TPlugin extends Plugin<infer TContext>
-      ? TContext
-      : never
-    : never
-)>;

--- a/plugins/graphql/src/app/types.ts
+++ b/plugins/graphql/src/app/types.ts
@@ -15,10 +15,16 @@ export type CatalogApi = Pick<Client, "getEntityByRef">;
 
 export type EnvelopPlugins = Parameters<typeof envelop>[0]['plugins']
 
-export type Context<TPlugins extends EnvelopPlugins> = (
+type Merge<T> = {
+  [K in T extends any ? keyof T : never]: T extends { [key in K]: infer V }
+  ? V
+  : never
+}
+
+export type Context<TPlugins extends EnvelopPlugins> = Merge<(
   TPlugins extends Array<infer TPlugin>
     ? TPlugin extends Plugin<infer TContext>
       ? TContext
       : never
     : never
-);
+)>;

--- a/plugins/graphql/src/tests/graphql.test.ts
+++ b/plugins/graphql/src/tests/graphql.test.ts
@@ -145,14 +145,18 @@ describe('querying the graphql API', () => {
         entity(kind: "Component", name: "backstage") {
           name
           ...on Component {
-            subComponents { name }
+            subComponents {
+              edges {
+                node { name }
+              }
+            }
           }
         }
       `),
     ).toMatchObject({
       entity: {
         name: 'backstage',
-        subComponents: [{ name: 'lighting' }]
+        subComponents: { edges: [{ node: { name: 'lighting' } }] }
       }
     });
   });
@@ -163,20 +167,24 @@ describe('querying the graphql API', () => {
         entity(kind: "Component", name: "backstage") {
           name
           ...on Component {
-            providesApi { name }
-            consumesApi { name }
+            providesApi {
+              edges {
+                node { name }
+              }
+            }
+            consumesApi {
+              edges {
+                node { name }
+              }
+            }
           }
         }
       `),
     ).toMatchObject({
       entity: {
         name: 'backstage',
-        providesApi: expect.arrayContaining([{
-          name: 'backstage-backend-api',
-        }]),
-        consumesApi: expect.arrayContaining([{
-          name: 'github-enterprise',
-        }])
+        providesApi: { edges: expect.arrayContaining([{ node: { name: 'backstage-backend-api' } }]) },
+        consumesApi: { edges: expect.arrayContaining([{ node: { name: 'github-enterprise' } }]) }
       }
     });
   });
@@ -188,7 +196,11 @@ describe('querying the graphql API', () => {
           name
           ...on Component {
             dependencies {
-              ...on Resource { name }
+              edges {
+                node {
+                  ... on Resource { name }
+                }
+              }
             }
           }
         }
@@ -196,15 +208,15 @@ describe('querying the graphql API', () => {
     ).toMatchObject({
       entity: {
         name: 'backstage',
-        dependencies: expect.arrayContaining([{ name: 'artists-db' }]),
+        dependencies: { edges: expect.arrayContaining([{ node: { name: 'artists-db' } }]) },
       }
     });
   });
 
-  it.skip("can look up components hierarchy", function* () {
+  it("can look up components hierarchy", function* () {
     expect(
       yield harness.query(/* GraphQL */`
-        entity(kind: "Component", name: "wayback-archive-storage") {
+        entity(kind: "Component", name: "backstage") {
           description
           ...on Component {
             component {
@@ -216,8 +228,8 @@ describe('querying the graphql API', () => {
       `),
     ).toMatchObject({
       entity: {
-        description: 'Storage subsystem of the Wayback Archive',
-        component: { name: 'wayback-archive', description: 'Archive of the wayback machine' }
+        description: 'An example of a Backstage application.',
+        component: { name: 'culpa-vel-voluptates', description: 'Officiis necessitatibus a debitis a facere error.' }
       }
     });
   });
@@ -249,9 +261,13 @@ describe('querying the graphql API', () => {
           name
           ...on User {
             memberOf {
-              name
-              displayName
-              email
+              edges {
+                node {
+                  name
+                  displayName
+                  email
+                }
+              }
             }
           }
         }
@@ -291,8 +307,12 @@ describe('querying the graphql API', () => {
           name
           ...on Group {
             children {
-              name
-              displayName
+              edges {
+                node {
+                  name
+                  displayName
+                }
+              }
             }
           }
         }
@@ -318,8 +338,12 @@ describe('querying the graphql API', () => {
           name
           ...on Group {
             members {
-              name
-              email
+              edges {
+                node {
+                  name
+                  email
+                }
+              }
             }
           }
         }

--- a/plugins/graphql/src/tests/mapper.test.ts
+++ b/plugins/graphql/src/tests/mapper.test.ts
@@ -552,10 +552,4 @@ describe('Transformer', () => {
       }
     })
   })
-
-  // TODO Tests:
-  // resolvers?
-  // relation to Connection
-  // relation `kind` argument
-  // relation Connection to union
 });

--- a/plugins/graphql/src/tests/mapper.test.ts
+++ b/plugins/graphql/src/tests/mapper.test.ts
@@ -1,0 +1,561 @@
+/* eslint-disable func-names */
+/* eslint-disable jest/no-standalone-expect */
+
+import { describe, it } from '@effection/jest';
+import { loadFilesSync } from '@graphql-tools/load-files';
+import { mergeTypeDefs } from '@graphql-tools/merge';
+import DataLoader from 'dataloader';
+import { buildASTSchema, DocumentNode, GraphQLNamedType, printType, validateSchema } from 'graphql';
+import { createModule, gql } from 'graphql-modules';
+import { transformDirectives } from '../app/mappers';
+import { createGraphQLTestApp } from './setupTests';
+
+describe('Transformer', () => {
+  const graphqlHeader = loadFilesSync(require.resolve('../app/modules/core/core.graphql'));
+  const transformSchema = (source: DocumentNode) => {
+    const schema = (
+    transformDirectives(
+      buildASTSchema(
+        mergeTypeDefs([source, graphqlHeader])
+        )
+      )
+    )
+    const errors = validateSchema(schema);
+    if (errors.length > 0) {
+      throw new Error(errors.map(e => e.message).join('\n'));
+    }
+    return schema
+  }
+
+  it('should add object type if empty @extend directive is used', function* () {
+    const schema = transformSchema(gql`
+    interface Entity @extend {
+      totalCount: Int!
+    }
+    `)
+    expect(printType(schema.getType('EntityImpl') as GraphQLNamedType).split('\n')).toEqual([
+      'type EntityImpl implements Entity {',
+      '  totalCount: Int!',
+      '}'
+    ]);
+  })
+
+  it('should merge fields from interface in @extend directive type', function* () {
+    const schema = transformSchema(gql`
+    interface Entity @extend(interface: "Node") {
+      name: String!
+    }
+    `)
+    expect(printType(schema.getType('Entity') as GraphQLNamedType).split('\n')).toEqual([
+      'interface Entity implements Node {',
+      '  id: ID!',
+      '  name: String!',
+      '}'
+    ]);
+  })
+
+  it('should add object type with merged fields from interfaces', function* () {
+    const schema = transformSchema(gql`
+    interface Entity @extend(interface: "Node") {
+      name: String!
+    }
+    `)
+    expect(printType(schema.getType('EntityImpl') as GraphQLNamedType).split('\n')).toEqual([
+      'type EntityImpl implements Entity & Node {',
+      '  id: ID!',
+      '  name: String!',
+      '}'
+    ]);
+  })
+
+  it('should merge fields for basic types', function* () {
+    const schema = transformSchema(gql`
+    interface Connection {
+      foobar: String!
+    }
+    `)
+    expect(printType(schema.getType('Connection') as GraphQLNamedType).split('\n')).toEqual([
+      'interface Connection {',
+      '  foobar: String!',
+      '  pageInfo: PageInfo!',
+      '  edges: [Edge!]!',
+      '  total: Int',
+      '}'
+    ]);
+  })
+
+  it('should merge union types', function* () {
+    const schema = transformSchema(gql`
+    interface Component @extend {
+      name: String!
+    }
+    interface Resource @extend {
+      name: String!
+    }
+
+    union Entity = Component
+
+    extend union Entity = Resource
+    `)
+    expect(printType(schema.getType('Entity') as GraphQLNamedType).split('\n')).toEqual([
+      'union Entity = ComponentImpl | ResourceImpl'
+    ]);
+  })
+
+  it('should add subtypes to a union type', function* () {
+    const schema = transformSchema(gql`
+    union Ownable = Entity
+
+    interface Entity @extend {
+      name: String!
+    }
+    interface Resource @extend(interface: "Entity") {
+      location: String!
+    }
+    interface WebResource @extend(interface: "Resource", when: "spec.type", is: "website") {
+      url: String!
+    }
+    interface User @extend {
+      ownerOf: [Ownable!]! @relation
+    }
+    `)
+    expect(printType(schema.getType('Ownable') as GraphQLNamedType).split('\n')).toEqual([
+      'union Ownable = EntityImpl | ResourceImpl | WebResourceImpl'
+    ]);
+  })
+
+  it('should extend a types sequence', function* () {
+    const schema = transformSchema(gql`
+    interface Entity @extend(interface: "Node") {
+      name: String!
+    }
+    interface Resource @extend(interface: "Entity", when: "kind", is: "Resource") {
+      location: String!
+    }
+    interface WebResource @extend(interface: "Resource", when: "spec.type", is: "website") {
+      url: String!
+    }
+    interface ExampleCom @extend(interface: "WebResource", when: "spec.url", is: "example.com") {
+      example: String!
+    }
+    `)
+    expect(printType(schema.getType('ExampleCom') as GraphQLNamedType).split('\n')).toEqual([
+      'interface ExampleCom implements WebResource & Resource & Entity & Node {',
+      '  id: ID!',
+      '  name: String!',
+      '  location: String!',
+      '  url: String!',
+      '  example: String!',
+      '}'
+    ]);
+  })
+
+  it('should add arguments to the "Connection" type', function* () {
+    const schema = transformSchema(gql`
+    interface Group @extend(interface: "Node") {
+      users: Connection @relation(type: "hasMember", interface: "User")
+    }
+
+    interface User @extend(interface: "Node", when: "kind", is: "User") {
+      name: String!
+    }
+    `)
+    expect(printType(schema.getType('Group') as GraphQLNamedType).split('\n')).toEqual([
+      'interface Group implements Node {',
+      '  id: ID!',
+      '  users(first: Int, after: String, last: Int, before: String): UserConnection',
+      '}'
+    ]);
+  })
+
+  it('should override union type to interface if it has been used in a @relation directive with "Connection" type', function* () {
+    const schema = transformSchema(gql`
+    union Ownable = Entity
+
+    interface Entity @extend(interface: "Node") {
+      name: String!
+    }
+    interface Resource @extend(interface: "Entity", when: "kind", is: "Resource") {
+      location: String!
+    }
+    interface User @extend {
+      owns: Connection @relation(type: "ownerOf", interface: "Ownable")
+    }
+    `)
+    expect(printType(schema.getType('Ownable') as GraphQLNamedType).split('\n')).toEqual([
+      'interface Ownable implements Node {',
+      '  id: ID!',
+      '}'
+    ]);
+    expect(printType(schema.getType('Entity') as GraphQLNamedType).split('\n')).toEqual([
+      'interface Entity implements Ownable & Node {',
+      '  id: ID!',
+      '  name: String!',
+      '}'
+    ]);
+    expect(printType(schema.getType('Resource') as GraphQLNamedType).split('\n')).toEqual([
+      'interface Resource implements Ownable & Entity & Node {',
+      '  id: ID!',
+      '  name: String!',
+      '  location: String!',
+      '}'
+    ]);
+    expect(printType(schema.getType('OwnableConnection') as GraphQLNamedType).split('\n')).toEqual([
+      'type OwnableConnection implements Connection {',
+      '  pageInfo: PageInfo!',
+      '  edges: [OwnableEdge!]!',
+      '  total: Int',
+      '}'
+    ]);
+    expect(printType(schema.getType('User') as GraphQLNamedType).split('\n')).toEqual([
+      'interface User {',
+      '  owns(first: Int, after: String, last: Int, before: String): OwnableConnection',
+      '}'
+    ]);
+  })
+
+  it('should fail if `at` argument of @field is not a valid type', function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend {
+      name: String! @field(at: 42)
+    }
+    `)).toThrow('The "at" argument of @field directive must be a string or an array of strings');
+  })
+
+  it('should fail if `when` argument of @extend is not a valid type', function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend(when: 42, is: "answer") {
+      name: String!
+    }
+    `)).toThrow('The "when" argument of @extend directive must be a string or an array of strings');
+  })
+
+  it('should fail if `when` argument is used without `is` in @extend directive', function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend(when: "kind") {
+      name: String!
+    }
+    `)).toThrow('The @extend directive for "Entity" should have both "when" and "is" arguments or none of them');
+  })
+
+  it("should fail if @relation interface doesn't exist", function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend {
+      owners: Connection @relation(type: "ownedBy", interface: "Owner")
+    }
+    `)).toThrow('Error while processing directives on field "owners" of "Entity":\nThe interface "Owner" is not defined in the schema.');
+  })
+
+  it('should fail if @relation interface is input type', function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend {
+      owners: Connection @relation(type: "ownedBy", interface: "OwnerInput")
+    }
+    input OwnerInput {
+      name: String!
+    }
+    `)).toThrow(`Error while processing directives on field "owners" of "Entity":\nThe interface "OwnerInput" is an input type and can't be used in a Connection.`);
+  })
+
+  it("should fail if @extend interface doesn't exist", function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend(interface: "NonExistingInterface") {
+      name: String!
+    }
+    `)).toThrow(`The interface "NonExistingInterface" described in @extend directive for "Entity" isn't abstract type or doesn't exist`);
+  })
+
+  it("should fail if @extend interface isn't an interface", function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend(interface: "String") {
+      name: String!
+    }
+    `)).toThrow(`The interface "String" described in @extend directive for "Entity" isn't abstract type or doesn't exist`);
+  })
+
+  it('should fail if @extend interface is already implemented by the type', function* () {
+    expect(() => transformSchema(gql`
+    interface Entity implements Node @extend(interface: "Node") {
+      name: String!
+    }
+    `)).toThrow(`The interface "Node" described in @extend directive for "Entity" is already implemented by the type`);
+  })
+
+  it('should fail if Connection type is in a list', function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend {
+      owners: [Connection] @relation(type: "ownedBy", interface: "Owner")
+    }
+    interface Owner @extend {
+      name: String!
+    }
+    `)).toThrow(`Error while processing directives on field "owners" of "Entity":\nIt's not possible to use a list of Connection type. Use either Connection type or list of specific type`);
+  })
+
+  it('should fail if Connection has arguments are not valid types', function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend {
+      owners(first: String!, after: Int!): Connection @relation(type: "ownedBy", interface: "Owner")
+    }
+    interface Owner @extend {
+      name: String!
+    }
+    `)).toThrow(`Error while processing directives on field "owners" of "Entity":\nThe field has mandatory argument \"first\" with different type than expected. Expected: Int`);
+  })
+
+  it('should fail if @relation and @field are used on the same field', function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend {
+      owners: Connection @relation(type: "ownedBy", interface: "Owner") @field(at: "name")
+    }
+    interface Owner @extend {
+      name: String!
+    }
+    `)).toThrow(`The field "owners" of "Entity" type has both @field and @relation directives at the same time`);
+  })
+
+  it('should fail if @extend without when/is is used more than once', function* () {
+    expect(() => transformSchema(gql`
+    interface Entity @extend(interface: "Node") {
+      name: String!
+    }
+    interface Component @extend(interface: "Node") {
+      name: String!
+    }
+    `)).toThrow(`The @extend directive of "Node" without "when" and "is" arguments could be used only once`);
+  })
+
+  it('should fail if subtype with required fields extends without when/is arguments from type without when/is arguments', function* () {
+    const getSchema = () => transformSchema(gql`
+    interface Entity @extend {
+      name: String!
+    }
+    interface Resource @extend(interface: "Entity") {
+      location: String!
+    }
+    interface WebResource @extend(interface: "Resource") {
+      url: String!
+    }
+    `)
+    expect(getSchema).toThrow(`The interface "WebResource" has required fields and can't be extended from "Resource" without "when" and "is" arguments, because "Resource" has already been extended without them`);
+  })
+
+  it('should add resolver for @field directive', function* () {
+    const TestModule = createModule({
+      id: 'test',
+      typeDefs: gql`
+      interface Entity @extend(interface: "Node") {
+        first: String! @field(at: "metadata.name")
+        second: String! @field(at: ["spec", "path.to.name"])
+      }
+      `,
+    })
+    const entity = {
+      metadata: { name: 'hello' },
+      spec: { "path.to.name": 'world' }
+    };
+    const loader = () => new DataLoader(async () => [entity]);
+    const query = createGraphQLTestApp(TestModule, loader)
+    const result = yield query(/* GraphQL */`
+      node(id: "test") { ...on Entity { first, second } }
+    `)
+    expect(result).toEqual({
+      node: {
+        first: 'hello',
+        second: 'world'
+      }
+    })
+  })
+
+  it('should add resolver for @relation directive with single item', function* () {
+    const TestModule = createModule({
+      id: 'test',
+      typeDefs: gql`
+      interface Entity @extend(interface: "Node", when: "kind", is: "Entity") {
+        ownedBy: User @relation
+        owner: User @relation(type: "ownedBy")
+        group: Group @relation(type: "ownedBy", kind: "Group")
+      }
+      interface User @extend(interface: "Node", when: "kind", is: "User") {
+        name: String! @field
+      }
+      interface Group @extend(interface: "Node", when: "kind", is: "Group") {
+        name: String! @field
+      }
+      `,
+    })
+    const entity = {
+      kind: 'Entity',
+      relations: [
+        { type: 'ownedBy', targetRef: 'user:default/john' },
+        { type: 'ownedBy', targetRef: 'group:default/team-a' }
+      ]
+    };
+    const user = {
+      kind: 'User',
+      name: 'John'
+    };
+    const group = {
+      kind: 'Group',
+      name: 'Team A'
+    };
+    const loader = () => new DataLoader(async (ids) => ids.map(id => {
+      if (id === 'user:default/john') return user
+      if (id === 'group:default/team-a') return group
+      return entity
+    }));
+    const query = createGraphQLTestApp(TestModule, loader)
+    const result = yield query(/* GraphQL */`
+      node(id: "entity") {
+        ...on Entity {
+          ownedBy { name }
+          owner { name }
+          group { name }
+        }
+      }
+    `)
+    expect(result).toEqual({
+      node: {
+        ownedBy: { name: 'John' },
+        owner: { name: 'John' },
+        group: { name: 'Team A' }
+      }
+    })
+  })
+
+  it('should add resolver for @relation directive with a list', function* () {
+    const TestModule = createModule({
+      id: 'test',
+      typeDefs: gql`
+      union Owner = User | Group
+
+      interface Entity @extend(interface: "Node", when: "kind", is: "Entity") {
+        ownedBy: [Owner] @relation
+        owners: [Owner] @relation(type: "ownedBy")
+        users: [User] @relation(type: "ownedBy") # We intentionally don't specify kind here
+        groups: [Group] @relation(type: "ownedBy", kind: "Group")
+      }
+      interface User @extend(interface: "Node", when: "kind", is: "User") {
+        username: String! @field(at: "name")
+      }
+      interface Group @extend(interface: "Node", when: "kind", is: "Group") {
+        groupname: String! @field(at: "name")
+      }
+      `,
+    })
+    const entity = {
+      kind: 'Entity',
+      relations: [
+        { type: 'ownedBy', targetRef: 'user:default/john' },
+        { type: 'ownedBy', targetRef: 'group:default/team-b' },
+        { type: 'ownedBy', targetRef: 'user:default/mark' },
+        { type: 'ownedBy', targetRef: 'group:default/team-a' }
+      ]
+    };
+    const john = { kind: 'User', name: 'John' };
+    const mark = { kind: 'User', name: 'Mark' };
+    const teamA = { kind: 'Group', name: 'Team A' };
+    const teamB = { kind: 'Group', name: 'Team B' };
+    const loader = () => new DataLoader(async (ids) => ids.map(id => {
+      if (id === 'user:default/john') return john
+      if (id === 'user:default/mark') return mark
+      if (id === 'group:default/team-a') return teamA
+      if (id === 'group:default/team-b') return teamB
+      return entity
+    }));
+    const query = createGraphQLTestApp(TestModule, loader)
+    const result = yield query(/* GraphQL */`
+      node(id: "entity") {
+        ...on Entity {
+          ownedBy { ...on User { username }, ...on Group { groupname } }
+          owners { ...on Group { groupname }, ...on User { username } }
+          users { username }
+          groups { groupname }
+        }
+      }
+    `)
+    expect(result).toEqual({
+      node: {
+        ownedBy: [{ username: 'John' }, { groupname: 'Team B' }, { username: 'Mark' }, { groupname: 'Team A' }],
+        owners: [{ username: 'John' }, { groupname: 'Team B' }, { username: 'Mark' }, { groupname: 'Team A' }],
+        users: [{ username: 'John' }, { username: 'Team B' }, { username: 'Mark' }, { username: 'Team A' }],
+        groups: [{ groupname: 'Team B' }, { groupname: 'Team A' }]
+      }
+    })
+  })
+
+  it('should add resolver for @relation directive with a connection', function* () {
+    const TestModule = createModule({
+      id: 'test',
+      typeDefs: gql`
+      union Owner = User | Group
+
+      interface Entity @extend(interface: "Node", when: "kind", is: "Entity") {
+        ownedBy: Connection @relation
+        nodes: Connection @relation(type: "ownedBy")
+        owners: Connection @relation(type: "ownedBy", interface: "Owner")
+        users: Connection @relation(type: "ownedBy", interface: "User") # We intentionally don't specify kind here
+        groups: Connection @relation(type: "ownedBy", kind: "Group", interface: "Group")
+      }
+      interface User @extend(interface: "Node", when: "kind", is: "User") {
+        username: String! @field(at: "name")
+      }
+      interface Group @extend(interface: "Node", when: "kind", is: "Group") {
+        groupname: String! @field(at: "name")
+      }
+      `,
+    })
+    const entity = {
+      kind: 'Entity',
+      relations: [
+        { type: 'ownedBy', targetRef: 'user:default/john' },
+        { type: 'ownedBy', targetRef: 'group:default/team-b' },
+        { type: 'ownedBy', targetRef: 'user:default/mark' },
+        { type: 'ownedBy', targetRef: 'group:default/team-a' }
+      ]
+    };
+    const john = { kind: 'User', name: 'John' };
+    const mark = { kind: 'User', name: 'Mark' };
+    const teamA = { kind: 'Group', name: 'Team A' };
+    const teamB = { kind: 'Group', name: 'Team B' };
+    const loader = () => new DataLoader(async (ids) => ids.map(id => {
+      if (id === 'user:default/john') return john
+      if (id === 'user:default/mark') return mark
+      if (id === 'group:default/team-a') return teamA
+      if (id === 'group:default/team-b') return teamB
+      return entity
+    }));
+    const query = createGraphQLTestApp(TestModule, loader)
+    const result = yield query(/* GraphQL */`
+      node(id: "entity") {
+        ...on Entity {
+          ownedBy(first: 2) { edges { node { ...on User { username }, ...on Group { groupname } } } }
+          nodes(first: 2, after: "YXJyYXljb25uZWN0aW9uOjE=") { edges { node { ...on Group { groupname }, ...on User { username } } } }
+          owners(last: 2) { edges { node { id, ...on User { username } } } }
+          users { edges { node { username } } }
+          groups { edges { node { groupname } } }
+        }
+      }
+    `)
+    expect(result).toEqual({
+      node: {
+        ownedBy: { edges: [{ node: { username: 'John' } }, { node: { groupname: 'Team B' } }] },
+        nodes: { edges: [{ node: { username: 'Mark' } }, { node: { groupname: 'Team A' } }] },
+        owners: { edges: [{ node: { id: 'user:default/mark', username: 'Mark' } }, { node: { id: 'group:default/team-a' } }] },
+        users: { edges: [
+          { node: { username: 'John' } },
+          { node: { username: 'Team B' } },
+          { node: { username: 'Mark' } },
+          { node: { username: 'Team A' } }
+        ] },
+        groups: { edges: [{ node: { groupname: 'Team B' } }, { node: { groupname: 'Team A' } }] },
+      }
+    })
+  })
+
+  // TODO Tests:
+  // resolvers?
+  // relation to Connection
+  // relation `kind` argument
+  // relation Connection to union
+});

--- a/plugins/graphql/src/tests/setupTests.ts
+++ b/plugins/graphql/src/tests/setupTests.ts
@@ -4,7 +4,7 @@ import type { JsonObject } from '@backstage/types';
 import type { Operation } from 'effection';
 import type { Node } from '@frontside/graphgen';
 
-import { EnvelopError, PromiseOrValue } from '@envelop/core';
+import { EnvelopError, PromiseOrValue, useExtendContext } from '@envelop/core';
 import { createGraphQLApp } from '..';
 
 import type { Factory, World } from '@frontside/graphgen-backstage';
@@ -19,12 +19,10 @@ export interface GraphQLHarness {
 
 export function createGraphQLAPI(): GraphQLHarness {
   let factory = createFactory();
-  let catalog = createSimulatedCatalog(factory);
   let { run, application } = createGraphQLApp({
-    catalog,
     modules: [],
-    plugins: [],
-    loader: () => createSimulatedLoader(catalog),
+    plugins: [useExtendContext(() => ({ catalog: createSimulatedCatalog(factory) }))],
+    loader: ({ catalog }) => createSimulatedLoader(catalog),
   });
 
   return {

--- a/plugins/graphql/src/tests/setupTests.ts
+++ b/plugins/graphql/src/tests/setupTests.ts
@@ -1,5 +1,5 @@
-import { Entity, EntityRelation, stringifyEntityRef } from '@backstage/catalog-model';
-import type { CatalogApi, EntityRef, Loader } from '../app/types';
+import { Entity, EntityRelation, parseEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
+import type { EntityRef, Loader } from '../app/types';
 import type { JsonObject } from '@backstage/types';
 import type { Operation } from 'effection';
 import type { Node } from '@frontside/graphgen';
@@ -10,6 +10,9 @@ import { createGraphQLApp } from '..';
 import type { Factory, World } from '@frontside/graphgen-backstage';
 import { createFactory } from '@frontside/graphgen-backstage';
 import DataLoader from 'dataloader';
+import type { CatalogClient } from '@backstage/catalog-client';
+
+export type CatalogApi = Pick<CatalogClient, "getEntityByRef">;
 
 export interface GraphQLHarness {
   query(query: string): Operation<JsonObject>;
@@ -63,7 +66,7 @@ export function createGraphQLAPI(): GraphQLHarness {
 export function createSimulatedLoader(catalog: CatalogApi): Loader {
   return new DataLoader<EntityRef, Entity>(function fetch(refs): Promise<Array<Entity | Error>> {
     return Promise.all(refs.map(async ref => {
-      let entity = await catalog.getEntityByRef(ref);
+      let entity = await catalog.getEntityByRef(parseEntityRef(ref, { defaultNamespace: 'default' }));
       return entity ?? new EnvelopError(`no such node with ref: '${ref}'`);
     }));
   });

--- a/plugins/graphql/src/tests/setupTests.ts
+++ b/plugins/graphql/src/tests/setupTests.ts
@@ -19,10 +19,12 @@ export interface GraphQLHarness {
 
 export function createGraphQLAPI(): GraphQLHarness {
   let factory = createFactory();
+  let catalog = createSimulatedCatalog(factory)
   let { run, application } = createGraphQLApp({
-    modules: [],
-    plugins: [useExtendContext(() => ({ catalog: createSimulatedCatalog(factory) }))],
-    loader: ({ catalog }) => createSimulatedLoader(catalog),
+    envelopOptions: {
+      plugins: [useExtendContext(() => ({ catalog }))],
+      loader: () => createSimulatedLoader(catalog)
+    }
   });
 
   return {

--- a/plugins/graphql/src/tests/setupTests.ts
+++ b/plugins/graphql/src/tests/setupTests.ts
@@ -21,10 +21,10 @@ export function createGraphQLAPI(): GraphQLHarness {
   let factory = createFactory();
   let catalog = createSimulatedCatalog(factory);
   let { run, application } = createGraphQLApp({
-    catalog: createSimulatedCatalog(factory),
+    catalog,
     modules: [],
     plugins: [],
-    loader: createSimulatedLoader(catalog),
+    loader: () => createSimulatedLoader(catalog),
   });
 
   return {

--- a/plugins/graphql/src/tests/setupTests.ts
+++ b/plugins/graphql/src/tests/setupTests.ts
@@ -21,10 +21,8 @@ export function createGraphQLAPI(): GraphQLHarness {
   let factory = createFactory();
   let catalog = createSimulatedCatalog(factory)
   let { run, application } = createGraphQLApp({
-    envelopOptions: {
-      plugins: [useExtendContext(() => ({ catalog }))],
-      loader: () => createSimulatedLoader(catalog)
-    }
+    plugins: [useExtendContext(() => ({ catalog }))],
+    loader: () => createSimulatedLoader(catalog),
   });
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3379,6 +3379,13 @@
   dependencies:
     "@envelop/types" "2.3.0"
 
+"@envelop/dataloader@^3.3.2":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@envelop/dataloader/-/dataloader-3.6.0.tgz#51b1697361f662ee8f9949f8dcccff82e3236607"
+  integrity sha512-SMECnpCyPmUS6nNLeKfvu7ow+8CMiMv7wset1nmkvC1+hjK5sGt3vBOvQ3MnsqxYmD8GkUKyI1Bl7TIs0HOHCA==
+  dependencies:
+    tslib "^2.4.0"
+
 "@envelop/graphql-modules@^3.3.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@envelop/graphql-modules/-/graphql-modules-3.4.0.tgz#91193e50e61e9a6103a661fd248c54bb55dc26a2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7440,12 +7440,19 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17", "@types/react-dom@^18.0.0":
+"@types/react-dom@*", "@types/react-dom@<18.0.0":
   version "17.0.17"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
   integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
   dependencies:
     "@types/react" "^17"
+
+"@types/react-dom@^18.0.0":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
+  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-redux@^7.1.20":
   version "7.1.24"
@@ -13283,6 +13290,11 @@ graphql-modules@^2.0.0, graphql-modules@^2.1.0:
     "@graphql-typed-document-node/core" "^3.1.0"
     ramda "^0.28.0"
 
+graphql-relay@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.10.0.tgz#3b661432edf1cb414cd4a132cf595350e524db2b"
+  integrity sha512-44yBuw2/DLNEiMypbNZBt1yMDbBmyVPVesPywnteGGALiBmdyy1JP8jSg8ClLePg8ZZxk0O4BLhd1a6U/1jDOQ==
+
 graphql-request@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.3.0.tgz#b934e08fcae764aa2cdc697d3c821f046cb5dbf2"
@@ -13309,10 +13321,20 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.9.1.tgz#9c0fa48ceb695d61d574ed3ab21b426729e87f2d"
   integrity sha512-mL/SWGBwIT9Meq0NlfS55yXXTOeWPMbK7bZBEZhFu46bcGk1coTx2Sdtzxdk+9yHWngD+Fk1PZDWaAutQa9tpw==
 
-graphql@*, graphql@16.5.0, "graphql@^15.0.0 || ^16.0.0", graphql@^15.5.1, graphql@^16.0.0, graphql@^16.3.0, graphql@^16.5.0:
+graphql@*, "graphql@^15.0.0 || ^16.0.0", graphql@^16.0.0, graphql@^16.3.0, graphql@^16.5.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
+
+graphql@16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
+  integrity sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==
+
+graphql@^15.5.1:
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
+  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
 gson-conform@^1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3345,16 +3345,6 @@
     chalk "^4.1.2"
     stacktrace-parser "^0.1.10"
 
-"@effection/process@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@effection/process/-/process-2.1.2.tgz#adc473ad9ed0916df3c34e0bba1f697ac29afb50"
-  integrity sha512-hwanPqnyA1fyQNDFwoRo6fqrbX7akgLPv4fXYEOETElDjaXuLA88FHBPaDm52IJv2KI49beq9krdEaobWmFmlA==
-  dependencies:
-    cross-spawn "^7.0.3"
-    ctrlc-windows "^2.1.0"
-    effection "2.0.6"
-    shellwords "^0.1.1"
-
 "@effection/react@2.2.2", "@effection/react@^2.2.2":
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/@effection/react/-/react-2.2.2.tgz#6b88a18605ee0baade2e8a017e1c0cdb7fb7e4c6"
@@ -3688,6 +3678,18 @@
     "@graphql-tools/utils" "^8.8.0"
     tslib "~2.4.0"
 
+"@graphql-codegen/graphql-modules-preset@^2.3.14":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/graphql-modules-preset/-/graphql-modules-preset-2.5.2.tgz#818edceff6dc2e8ca92425a802780d7ff568e112"
+  integrity sha512-TCIzxCnfuyJh0uDTYdebXue+wCDEqFRhskuAi5xEAT3a6KryRKGWekRHrmXvVX03nN0xHis220sJGfwVl1VgLw==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-codegen/visitor-plugin-common" "2.12.2"
+    "@graphql-tools/utils" "^8.8.0"
+    change-case-all "1.0.14"
+    parse-filepath "^1.0.2"
+    tslib "~2.4.0"
+
 "@graphql-codegen/graphql-modules-preset@^2.3.8":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/graphql-modules-preset/-/graphql-modules-preset-2.5.1.tgz#eb0c8c23457be866f7308b23b1d49d9d71d9a791"
@@ -3787,6 +3789,18 @@
     auto-bind "~4.0.0"
     tslib "~2.4.0"
 
+"@graphql-codegen/typescript-resolvers@^2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.7.4.tgz#3f60a7c56727edd80b1911c4689e258439ae8c85"
+  integrity sha512-6sE8Plh4lNxcbvFflP65ZnMWOh5fZYiMwi0CbN8VxE04Z360l9ACHkOrbidX/9OqJOwQNdeVSJ5gZIKaoDrTBw==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-codegen/typescript" "^2.7.4"
+    "@graphql-codegen/visitor-plugin-common" "2.12.2"
+    "@graphql-tools/utils" "^8.8.0"
+    auto-bind "~4.0.0"
+    tslib "~2.4.0"
+
 "@graphql-codegen/typescript@2.7.3", "@graphql-codegen/typescript@^2.7.3":
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.7.3.tgz#ad786a1c74e16eca8e01e7a8f28078e1c24eeb61"
@@ -3806,6 +3820,17 @@
     "@graphql-codegen/plugin-helpers" "^2.5.0"
     "@graphql-codegen/schema-ast" "^2.5.0"
     "@graphql-codegen/visitor-plugin-common" "2.11.1"
+    auto-bind "~4.0.0"
+    tslib "~2.4.0"
+
+"@graphql-codegen/typescript@^2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.7.4.tgz#46c1fac63ae1b487efe73db6531f1db5e5198fe0"
+  integrity sha512-mjoE3KqmAaBUSlCuKb2WDot3+CTfdJ9eKIcWsDFubPTNdZE0Z8mLoATmVryx8NOBjDtPU/ZziI0rYEGOR4qpAw==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-codegen/schema-ast" "^2.5.1"
+    "@graphql-codegen/visitor-plugin-common" "2.12.2"
     auto-bind "~4.0.0"
     tslib "~2.4.0"
 
@@ -3829,6 +3854,22 @@
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.12.1.tgz#8d2d24b572afd396381dddef7e2032b0f73c05cc"
   integrity sha512-dIUrX4+i/uazyPQqXyQ8cqykgNFe1lknjnfDWFo0gnk2W8+ruuL2JpSrj/7efzFHxbYGMQrCABDCUTVLi3DcVA==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-tools/optimize" "^1.3.0"
+    "@graphql-tools/relay-operation-optimizer" "^6.5.0"
+    "@graphql-tools/utils" "^8.8.0"
+    auto-bind "~4.0.0"
+    change-case-all "1.0.14"
+    dependency-graph "^0.11.0"
+    graphql-tag "^2.11.0"
+    parse-filepath "^1.0.2"
+    tslib "~2.4.0"
+
+"@graphql-codegen/visitor-plugin-common@2.12.2":
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.12.2.tgz#70eefed5567dbec6d289b05047b04bc9faae428e"
+  integrity sha512-UZJxY3mWwaM7yii7mSbl6Rxb6sJlpwGZc3QAs2Yd8MnYjXFPTBR0OO6aBTr9xuftl0pYwHu/pVK7vTPNnVmPww==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^2.6.2"
     "@graphql-tools/optimize" "^1.3.0"
@@ -10438,11 +10479,6 @@ csv@^5.5.0:
     csv-stringify "^5.6.5"
     stream-transform "^2.1.3"
 
-ctrlc-windows@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ctrlc-windows/-/ctrlc-windows-2.1.0.tgz#f2096a96ac1d03181e0ec808c2c8a67fdc20b300"
-  integrity sha512-OrX5KI+K+2NMN91QIhYZdW7VDO2YsSdTZW494pA7Nvw/wBdU2hz+MGP006bR978zOTrG6Q8EIeJvLJmLqc6MsQ==
-
 cypress@^9.7.0:
   version "9.7.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.7.0.tgz#bf55b2afd481f7a113ef5604aa8b693564b5e744"
@@ -13240,11 +13276,6 @@ graphql-modules@^2.0.0, graphql-modules@^2.1.0:
     "@graphql-typed-document-node/core" "^3.1.0"
     ramda "^0.28.0"
 
-graphql-relay@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.10.0.tgz#3b661432edf1cb414cd4a132cf595350e524db2b"
-  integrity sha512-44yBuw2/DLNEiMypbNZBt1yMDbBmyVPVesPywnteGGALiBmdyy1JP8jSg8ClLePg8ZZxk0O4BLhd1a6U/1jDOQ==
-
 graphql-request@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.3.0.tgz#b934e08fcae764aa2cdc697d3c821f046cb5dbf2"
@@ -13266,7 +13297,7 @@ graphql-type-json@^0.3.2:
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
   integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
 
-graphql-ws@^5.4.1, graphql-ws@^5.6.4:
+graphql-ws@^5.4.1:
   version "5.9.1"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.9.1.tgz#9c0fa48ceb695d61d574ed3ab21b426729e87f2d"
   integrity sha512-mL/SWGBwIT9Meq0NlfS55yXXTOeWPMbK7bZBEZhFu46bcGk1coTx2Sdtzxdk+9yHWngD+Fk1PZDWaAutQa9tpw==
@@ -20866,11 +20897,6 @@ shelljs@^0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
-
-shellwords@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
-  integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 shx@^0.3.4:
   version "0.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4053,6 +4053,14 @@
     "@graphql-tools/utils" "8.10.0"
     tslib "^2.4.0"
 
+"@graphql-tools/merge@^8.3.6":
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.6.tgz#97a936d4c8e8f935e58a514bb516c476437b5b2c"
+  integrity sha512-uUBokxXi89bj08P+iCvQk3Vew4vcfL5ZM6NTylWi8PIpoq4r5nJ625bRuN8h2uubEdRiH8ntN9M4xkd/j7AybQ==
+  dependencies:
+    "@graphql-tools/utils" "8.12.0"
+    tslib "^2.4.0"
+
 "@graphql-tools/optimize@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-1.3.0.tgz#11ea27ac73e857d882ccfd7a3a981d8d6fb521e2"
@@ -4170,6 +4178,13 @@
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.10.0.tgz#8e76db7487e19b60cf99fb90c2d6343b2105b331"
   integrity sha512-yI+V373FdXQbYfqdarehn9vRWDZZYuvyQ/xwiv5ez2BbobHrqsexF7qs56plLRaQ8ESYpVAjMQvJWe9s23O0Jg==
+  dependencies:
+    tslib "^2.4.0"
+
+"@graphql-tools/utils@8.12.0":
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.12.0.tgz#243bc4f5fc2edbc9e8fd1038189e57d837cbe31f"
+  integrity sha512-TeO+MJWGXjUTS52qfK4R8HiPoF/R7X+qmgtOYd8DTH0l6b+5Y/tlg5aGeUJefqImRq7nvi93Ms40k/Uz4D5CWw==
   dependencies:
     tslib "^2.4.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7440,19 +7440,12 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0":
-  version "17.0.17"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
-  integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
+"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17", "@types/react-dom@^18.0.0":
+  version "17.0.18"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.18.tgz#8f7af38f5d9b42f79162eea7492e5a1caff70dc2"
+  integrity sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==
   dependencies:
     "@types/react" "^17"
-
-"@types/react-dom@^18.0.0":
-  version "18.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
-  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
-  dependencies:
-    "@types/react" "*"
 
 "@types/react-redux@^7.1.20":
   version "7.1.24"
@@ -13321,20 +13314,10 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.9.1.tgz#9c0fa48ceb695d61d574ed3ab21b426729e87f2d"
   integrity sha512-mL/SWGBwIT9Meq0NlfS55yXXTOeWPMbK7bZBEZhFu46bcGk1coTx2Sdtzxdk+9yHWngD+Fk1PZDWaAutQa9tpw==
 
-graphql@*, "graphql@^15.0.0 || ^16.0.0", graphql@^16.0.0, graphql@^16.3.0, graphql@^16.5.0:
+graphql@*, graphql@16.5.0, "graphql@^15.0.0 || ^16.0.0", graphql@^15.5.1, graphql@^16.0.0, graphql@^16.3.0, graphql@^16.5.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
-
-graphql@16.5.0:
-  version "16.5.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
-  integrity sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==
-
-graphql@^15.5.1:
-  version "15.8.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
-  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
 gson-conform@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## Motivation

Closes #122 
Closes #75
Closes #128 

## Approach

- Expose `transformSchema` function for graphql codegen
- Expose `createLoader` for extending default data loader
- Allow provide custom data loader
- Fix overriding behavior for `@field` and `@relation` directives (When a child type defines the same field from parent but you want to resolve it differently) 
- Change how `@extend` works. Now it's working only on interfaces. So if you want to extend your type form any basic types like `Component/User/whatever` you should define your type as an interface. Then schema transformer, that handles these directives, adds an implementation for your interface as well any data what is resolved to particular interface will be resolved to its implementation implicitly. So you probably will not mess up with resolving things by yourself.
- `@relation` directive handles `Connection` type and schema transformer generates proper interfaces. If you use a union type for connection relation, the union will be changed to an interface.