### PR TITLE
Add github project slug

### DIFF
--- a/templates/standard-microservice/template.yaml
+++ b/templates/standard-microservice/template.yaml
@@ -40,6 +40,7 @@ spec:
           componentName: ${{ parameters.componentName }}
           orgId: ${{ steps.environment.output.orgId }}
           appId: ${{ parameters.componentName }}
+          repoUrl: ${{ parameters.repoUrl | parseRepoUrl }}
           registryUrl: ${{ steps.environment.output.registryUrl }}
     - name: Create Repository on Github
       id: publish

--- a/templates/standard-microservice/template/catalog-info.yaml
+++ b/templates/standard-microservice/template/catalog-info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ${{values.componentName | dump}}
   description: Sample service for Humanitec demo
   annotations:
+    "github.com/project-slug": ${{values.repoUrl | dump}}
     "humanitec.com/orgId": ${{values.orgId | dump}}
     "humanitec.com/appId": ${{values.appId | dump}}
 spec:


### PR DESCRIPTION
## Motivation

We did a demo of the IDP plugin today and we couldn't go through the entire flow because we were missing github project slug annotation.

## Approach

Added the annotation to the template