### PR TITLE
github.com/project-slug annotation must be a in form of `${owner}/{name}`

### DIFF
--- a/templates/standard-microservice/template/catalog-info.yaml
+++ b/templates/standard-microservice/template/catalog-info.yaml
@@ -4,9 +4,9 @@ metadata:
   name: ${{values.componentName | dump}}
   description: Sample service for Humanitec demo
   annotations:
-    "github.com/project-slug": ${{values.repoUrl | dump}}
-    "humanitec.com/orgId": ${{values.orgId | dump}}
-    "humanitec.com/appId": ${{values.appId | dump}}
+    github.com/project-slug: ${{values.repoUrl.owner + "/" + values.repoUrl.repo}}
+    humanitec.com/orgId: ${{values.orgId | dump}}
+    humanitec.com/appId: ${{values.appId | dump}}
 spec:
   type: service
   owner: john@example.com


### PR DESCRIPTION
## Motivation

#123 was merged without generating the correct project github.com/project-slug annotation because it's difficult to test this template.

## Approach

Update the template to use format similar to https://github.com/backstage/software-templates/blob/main/scaffolder-templates/docs-template/skeleton/catalog-info.yaml