### PR TITLE
Add help text to the main plugin install page

### DIFF
--- a/packages/backend/src/plugins/idp.ts
+++ b/packages/backend/src/plugins/idp.ts
@@ -25,7 +25,7 @@ export default async function createPlugin({
           return {
             ssh: `git@github.com:${slug}.git`,
             https: `https://github/${slug}.git`
-          }        
+          }
         }
 
         return null;

--- a/plugins/platform-backend/package.json
+++ b/plugins/platform-backend/package.json
@@ -32,7 +32,7 @@
     "express-promise-router": "^4.1.0",
     "js-yaml": "^4.1.0",
     "node-fetch-native": "^0.1.7",
-    "node-deno": "^0.0.4",
+    "node-deno": "^0.1.0",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.3",
     "request": "^2.88.2",

--- a/plugins/platform-backend/src/index.ts
+++ b/plugins/platform-backend/src/index.ts
@@ -16,4 +16,4 @@
 
 export * from './service/router';
 export * from './types';
-export type { Executables } from './executables';
+export type { DownloadInfo, Executables } from './executables';

--- a/plugins/platform-backend/src/service/router.ts
+++ b/plugins/platform-backend/src/service/router.ts
@@ -24,7 +24,7 @@ import fetch from 'node-fetch-native';
 import * as nunjucks from 'nunjucks';
 import request from 'request';
 import type { Logger } from 'winston';
-import { findOrCreateExecutables } from '../executables';
+import { getDownloadInfo } from '../executables';
 import { GetComponentRef, PlatformApi } from '../types';
 import { Repositories } from './routes/repositories';
 
@@ -41,12 +41,12 @@ export async function createRouter(
   options: RouterOptions,
   ): Promise<express.Router> {
   const { catalog, logger, discovery, executableName, appURL, platform } = options;
-    
+
   let baseURL = await discovery.getBaseUrl('idp');
   let downloadsURL = `${baseURL}/executables/dist`;
   let scaffolderUrl = `${await discovery.getBaseUrl('scaffolder')}/v2/tasks`;
 
-  let executables = findOrCreateExecutables({
+  let executables = getDownloadInfo({
     logger,
     distDir: 'dist-bin',
     baseURL,
@@ -130,7 +130,7 @@ export async function createRouter(
 
     try {
       const values = load(req.body) as Record<string, unknown>;
-  
+
       const post = await fetch(scaffolderUrl, {
         method: 'POST',
         headers: {
@@ -148,7 +148,7 @@ export async function createRouter(
       if(post.status !== 201) {
         throw new Error(`resource not created, ${post.status} - ${post.statusText}`);
       }
-  
+
       const { id } = (await post.json()) as { id: string };
 
       res.json({ taskId: id });
@@ -166,7 +166,7 @@ export async function createRouter(
 
     req.pipe(request(eventStreamUrl)).pipe(res);
   });
-  
+
   router.use('/repositories', Repositories({
     getComponentRef,
     platform,

--- a/plugins/platform/package.json
+++ b/plugins/platform/package.json
@@ -29,6 +29,7 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
+    "ansi-to-react": "^6.1.6",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
@@ -44,8 +45,8 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/jest": "*",
     "@types/node": "*",
-    "msw": "^0.42.0",
-    "cross-fetch": "^3.1.5"
+    "cross-fetch": "^3.1.5",
+    "msw": "^0.42.0"
   },
   "files": [
     "dist"

--- a/plugins/platform/src/api/executables-api.ts
+++ b/plugins/platform/src/api/executables-api.ts
@@ -1,4 +1,4 @@
-import type { Executables } from '@frontside/backstage-plugin-platform-backend';
+import type { DownloadInfo } from '@frontside/backstage-plugin-platform-backend';
 import { createApiRef } from '@backstage/core-plugin-api';
 
 export const executablesApiRef = createApiRef<ExecutablesAPI>({
@@ -6,5 +6,5 @@ export const executablesApiRef = createApiRef<ExecutablesAPI>({
 });
 
 export interface ExecutablesAPI {
-  fetchExecutables(): Promise<Executables>;
+  fetchExecutables(): Promise<DownloadInfo>;
 }

--- a/plugins/platform/src/components/AllExecutables/AllExecutables.tsx
+++ b/plugins/platform/src/components/AllExecutables/AllExecutables.tsx
@@ -4,10 +4,10 @@ import Alert from '@material-ui/lab/Alert';
 import useAsync from 'react-use/lib/useAsync';
 import { useApi } from '@backstage/core-plugin-api';
 
-import type { Executables } from '@frontside/backstage-plugin-platform-backend';
+import type { DownloadInfo } from '@frontside/backstage-plugin-platform-backend';
 import { executablesApiRef } from '../../api/executables-api';
 
-export const DenseTable = ({ executables }: { executables: Executables}) => {
+export const DenseTable = ({ info }: { info: DownloadInfo}) => {
 
   const columns: TableColumn[] = [
     { title: 'Architecture', field: 'target' },
@@ -15,10 +15,11 @@ export const DenseTable = ({ executables }: { executables: Executables}) => {
     { title: 'URL', field: 'url' },
   ];
 
-  let { executableName, ...binaries } = executables;
+  let { executableName, executables } = info;
 
-  const data = Object.entries(binaries).map(([target, executable]) => {
+  const data = Object.entries(executables).map(([target, executable]) => {
     return {
+      id: target,
       target,
       url: executable.type === 'compiled' ? executable.url : 'N/A',
       status: executable.type,
@@ -44,7 +45,7 @@ export const AllExecutables = () => {
   } else if (error) {
     return <Alert severity="error">{error.message}</Alert>;
   } else {
-    return <DenseTable executables={value ?? {} as Executables} />;
+    return <DenseTable info={value ?? {} as DownloadInfo} />;
   }
 
 };

--- a/plugins/platform/src/components/Install/Install.tsx
+++ b/plugins/platform/src/components/Install/Install.tsx
@@ -10,29 +10,59 @@ import {
   SupportButton,
 } from '@backstage/core-components';
 import { AllExecutables } from '../AllExecutables';
+import { executablesApiRef } from '../../api/executables-api';
+import { useApi } from '@backstage/core-plugin-api';
+import useAsync from 'react-use/lib/useAsync';
+import Ansi from 'ansi-to-react';
 
-export const Install = () => (
-  <Page themeId="tool">
-    <Header title="Welcome to platform!" subtitle="Optional subtitle">
-      <HeaderLabel label="Owner" value="Team X" />
-      <HeaderLabel label="Lifecycle" value="Alpha" />
-    </Header>
-    <Content>
-      <ContentHeader title="Plugin title">
-        <SupportButton>A description of your plugin goes here.</SupportButton>
-      </ContentHeader>
-      <Grid container spacing={3} direction="column">
-        <Grid item>
-          <InfoCard title="Information card">
-            <Typography variant="body1">
-              <span style={{"userSelect": "all"}}>curl -sSL http://localhost:7007/api/idp/install.sh | sh</span>
-            </Typography>
-          </InfoCard>
+export const useHelp = () => {
+  let api = useApi(executablesApiRef);
+  let info = useAsync(api.fetchExecutables, []);
+  if (info.loading) {
+    return { loading: true };
+  } else if (info.error) {
+    return info;
+  } else if (info.value?.helpText.type === 'rejected' ) {
+    return { loading: false, error: info.value.helpText.error };
+  } else if (info.value?.helpText.type === 'resolved') {
+    return { loading: false, value: info.value?.helpText.value };
+  } else {
+    return { loading: true };
+  }
+}
+
+export const Install = () => {
+  let helpText = useHelp();
+  return (
+    <Page themeId="tool">
+      <Header title="Internal Developer Platform tools" subtitle="Optional subtitle">
+        <HeaderLabel label="Owner" value="Team X" />
+        <HeaderLabel label="Lifecycle" value="Alpha" />
+      </Header>
+      <Content>
+        <ContentHeader title="Get Started">
+          <SupportButton>Install your company's platform tool</SupportButton>
+        </ContentHeader>
+        <Grid container spacing={3} direction="column">
+          <Grid item>
+            <InfoCard title="Install">
+              <Typography variant="body1">
+                <span style={{"userSelect": "all"}}>curl -sSL http://localhost:7007/api/idp/install.sh | sh</span>
+              </Typography>
+            </InfoCard>
+          </Grid>
+          <Grid item>
+            <InfoCard title="Help">
+              <Typography variant="body1" style={{whiteSpace: "pre"}}>
+                <Ansi>{helpText.error ? "" : helpText.value }</Ansi>
+              </Typography>
+            </InfoCard>
+          </Grid>
+          <Grid item>
+            <AllExecutables />
+          </Grid>
         </Grid>
-        <Grid item>
-          <AllExecutables />
-        </Grid>
-      </Grid>
-    </Content>
-  </Page>
-);
+      </Content>
+    </Page>
+  )
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7295,6 +7295,11 @@ alea@1.0.1:
   resolved "https://registry.yarnpkg.com/alea/-/alea-1.0.1.tgz#957f60741c5ad11b13f72aa02a6b89fe96a26dc4"
   integrity sha512-QU+wv+ziDXaMxRdsQg/aH7sVfWdhKps5YP97IIwFkHCsbDZA3k87JXoZ5/iuemf4ntytzIWeScrRpae8+lDrXA==
 
+anser@^1.4.1:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.10.tgz#befa3eddf282684bd03b63dcda3927aef8c2e35b"
+  integrity sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==
+
 ansi-colors@^4.1.1, ansi-colors@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
@@ -7350,6 +7355,14 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-to-react@^6.1.6:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/ansi-to-react/-/ansi-to-react-6.1.6.tgz#d6fe15ecd4351df626a08121b1646adfe6c02ccb"
+  integrity sha512-+HWn72GKydtupxX9TORBedqOMsJRiKTqaLUKW8txSBZw9iBpzPKLI8KOu4WzwD4R7hSv1zEspobY6LwlWvwZ6Q==
+  dependencies:
+    anser "^1.4.1"
+    escape-carriage "^1.3.0"
 
 any-promise@^1.0.0:
   version "1.3.0"
@@ -11020,6 +11033,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-carriage@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/escape-carriage/-/escape-carriage-1.3.0.tgz#71006b2d4da8cb6828686addafcb094239c742f3"
+  integrity sha512-ATWi5MD8QlAGQOeMgI8zTp671BG8aKvAC0M7yenlxU4CRLGO/sKthxVUyjiOFKjHdIo+6dZZUNFgHFeVEaKfGQ==
 
 escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
@@ -16814,10 +16832,10 @@ node-cache@^5.1.2:
   dependencies:
     clone "2.x"
 
-node-deno@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/node-deno/-/node-deno-0.0.4.tgz#62a0b7cba982c74908252d0e4d0a8c553a62b0ee"
-  integrity sha512-ZZe2sLojFzn9/lBMvcZ/gQ6cvs7U1IpLtxdOOXM4KUdd7QtkJ7Gb+VEJNj2JVDBT0OS8Gc090goBhKN2dsXqWg==
+node-deno@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/node-deno/-/node-deno-0.1.0.tgz#b70a9307d93db03bca69da0377ad3b396f4486e0"
+  integrity sha512-RPwAQZQHaadrejl83mDOq0LbNgefveH+QYOT1r5IUKmmqc/hKizNSt0xlWEDCy+Hvb5pCurk75FGK5XFb3eD0g==
   dependencies:
     "@effection/process" "^2.1.1"
     deno-bin "^1.26.0"


### PR DESCRIPTION
## Motivation

fixes #126 prep for demo

## Approach

invoke `main.ts` on system start to get the content of the help text.

## Screenshots

![shows help text output of internal developer tool](https://user-images.githubusercontent.com/4205/196700734-a7b3b40a-74c3-4098-8d50-f43bd728191d.png)
