### PR TITLE
Add streaming logs command and endpoint.

### DIFF
--- a/plugins/humanitec-common/src/clients/humanitec.ts
+++ b/plugins/humanitec-common/src/clients/humanitec.ts
@@ -60,6 +60,18 @@ export function createHumanitecClient({ orgId, token }: { token: string; orgId: 
       const result = await _fetch('GET', `apps/${appId}/envs/${envId}/resources`);
       return ResourcesResponsePayload.parse(result);
     },
+
+    async getEnvironmentLogsSnapshot(appId: string, envId: string) {
+      type Message = {
+        workload_id: string;
+        container_id: string;
+        payload: string;
+        level: string
+      };
+
+      return await _fetch<Message[]>('GET', `apps/${appId}/envs/${envId.toLowerCase()}/logs?limit=100&invert=true`);
+
+    },
     buildUrl(params: URLs) {
       const baseUrl = `https://app.humanitec.io/orgs/${orgId}`;
       switch (params.resource) {
@@ -89,6 +101,8 @@ export function createHumanitecClient({ orgId, token }: { token: string; orgId: 
 
       if (r.ok) {
         return await r.json() as R;
+      } else {
+        console.dir({ error: r.statusText });
       }
 
       throw new FetchError(`Fetch ${method} to ${url} failed.`, r);

--- a/plugins/humanitec-common/src/platform-api.ts
+++ b/plugins/humanitec-common/src/platform-api.ts
@@ -4,7 +4,9 @@ import type { Entity } from '@backstage/catalog-model';
 import { HUMANITEC_APP_ID_ANNOTATION, HUMANITEC_ORG_ID_ANNOTATION } from './constants';
 import { createHumanitecClient } from './clients/humanitec';
 
-export function createHumanitecPlatformApi({ token }: { token: string }): Partial<PlatformApi> {
+
+export type HumanitecPlatformAPI = Pick<PlatformApi, 'getLogs' | 'getEnvironments'>
+export function createHumanitecPlatformApi({ token }: { token: string }): HumanitecPlatformAPI {
 
   return {
     async *getLogs(ref, envId) {

--- a/plugins/platform-backend/cli/deps.ts
+++ b/plugins/platform-backend/cli/deps.ts
@@ -4,8 +4,8 @@ export * as yaml from "https://deno.land/std@0.159.0/encoding/yaml.ts";
 export { format } from "https://deno.land/std@0.159.0/datetime/mod.ts";
 export { Command } from "https://deno.land/x/cliffy@v0.25.2/command/mod.ts";
 export { EventSource } from "https://deno.land/x/eventsource@v0.0.2/mod.ts";
-export { red, blue, green } from "https://deno.land/std@0.159.0/fmt/colors.ts"
-export  { readAll } from "https://deno.land/std@0.159.0/streams/conversion.ts?s=copy";
+export { blue, green, red } from "https://deno.land/std@0.159.0/fmt/colors.ts";
+export { readAll } from "https://deno.land/std@0.159.0/streams/conversion.ts?s=copy";
 
 // we tried to get this from backstage. We really did.
 export interface Entity {

--- a/plugins/platform-backend/src/service/router.ts
+++ b/plugins/platform-backend/src/service/router.ts
@@ -27,6 +27,7 @@ import type { Logger } from 'winston';
 import { getDownloadInfo } from '../executables';
 import { GetComponentRef, PlatformApi } from '../types';
 import { Repositories } from './routes/repositories';
+import { Logs } from './routes/logs';
 
 export interface RouterOptions {
   logger: Logger;
@@ -168,6 +169,12 @@ export async function createRouter(
   });
 
   router.use('/repositories', Repositories({
+    getComponentRef,
+    platform,
+    catalog
+  }));
+
+  router.use('/logs', Logs({
     getComponentRef,
     platform,
     catalog

--- a/plugins/platform-backend/src/service/routes/logs.ts
+++ b/plugins/platform-backend/src/service/routes/logs.ts
@@ -1,7 +1,7 @@
 import type { CatalogClient } from '@backstage/catalog-client';
 import Router from 'express-promise-router';
 import express from 'express';
-import { EntityRef, GetComponentRef, PlatformApi } from '../../types';
+import { GetComponentRef, PlatformApi } from '../../types';
 
 interface RouteOptions {
   platform: PlatformApi;

--- a/plugins/platform-backend/src/service/routes/logs.ts
+++ b/plugins/platform-backend/src/service/routes/logs.ts
@@ -1,0 +1,51 @@
+import type { CatalogClient } from '@backstage/catalog-client';
+import Router from 'express-promise-router';
+import express from 'express';
+import { EntityRef, GetComponentRef, PlatformApi } from '../../types';
+
+interface RouteOptions {
+  platform: PlatformApi;
+  catalog: CatalogClient;
+  getComponentRef: GetComponentRef;
+}
+
+type Route = (options: RouteOptions) => express.Router;
+
+export const Logs: Route = ({ platform, getComponentRef }) => {
+  const router = Router();
+
+  router.get('/:component', async (req, response) => {
+    // Mandatory headers and http status to keep connection open
+    response.writeHead(200, {
+      'Connection': 'keep-alive',
+      'Cache-Control': 'no-cache',
+      'Content-Type': 'text/event-stream',
+    });
+
+    let closed = false;
+
+    req.on('close', () => {
+      closed = true;
+    });
+
+    let ref = await getComponentRef(req.params.component);
+    for await (const line of platform.getLogs(ref, "Development")) {
+      if (closed) {
+        return;
+      } else {
+        response.write(`${line}\n`);
+        flush(response);
+      }
+    }
+  });
+
+
+  return router;
+}
+
+function flush(response: express.Response) {
+  const flushable = response as unknown as { flush: Function };
+  if (typeof flushable.flush === 'function') {
+    flushable.flush();
+  }
+}

--- a/plugins/platform-backend/src/service/routes/repositories.ts
+++ b/plugins/platform-backend/src/service/routes/repositories.ts
@@ -1,11 +1,11 @@
-import type { CatalogClient } from '@backstage/catalog-client'; 
+import type { CatalogClient } from '@backstage/catalog-client';
 import CliTable3 from 'cli-table3';
 import chalk  from 'chalk';
 import Router from 'express-promise-router';
 import express from 'express';
 import { GetComponentRef, PlatformApi } from '../../types';
 
-interface RouteOptions { 
+interface RouteOptions {
   platform: PlatformApi;
   catalog: CatalogClient;
   getComponentRef: GetComponentRef;
@@ -36,7 +36,7 @@ export const Repositories: Route = ({ platform, getComponentRef }) => {
 
   router.get('/:component/urls', async (req, res) => {
     const name = req.params.component;
-    
+
     const ref = await getComponentRef(name);
     const urls = await platform.getRepositoryUrls(ref);
 
@@ -47,6 +47,6 @@ export const Repositories: Route = ({ platform, getComponentRef }) => {
       res.send("Not Found");
     }
   });
-  
+
   return router;
 }

--- a/plugins/platform-backend/src/types.ts
+++ b/plugins/platform-backend/src/types.ts
@@ -18,6 +18,7 @@ export interface RepositoryUrls {
 }
 
 export interface PlatformApi {
+  getLogs(ref: EntityRef, environment: string): AsyncIterable<string>;
   getEnvironments(ref: EntityRef, page?: PageSpec): Promise<Page<Environment>>;
   getRepositories(page?: PageSpec): Promise<Page<Repository>>
   getRepositoryUrls(ref: EntityRef): Promise<RepositoryUrls | null>


### PR DESCRIPTION
## Motivation

We want to be able to see the logs that are running in a current environment. This is really important when debugging.

## Approach

Add a `getLogs()` method to the platform api that takes an entity ref and environment and returns an async iterable representing the streaming logs.

I implemented this for the Humanitec platform api, but couldn't get the web socket implementation working, so we base it on  an HTTP get instead.

## Screenshots

![2022-10-23 21 51 10](https://user-images.githubusercontent.com/4205/197439315-c8ea7855-9a02-456e-91eb-56c237447551.gif)
