### PR TITLE
Deployment environment output in `idp` cli

### DIFF
--- a/plugins/humanitec-common/src/platform-api.ts
+++ b/plugins/humanitec-common/src/platform-api.ts
@@ -41,6 +41,8 @@ export function createHumanitecPlatformApi({ token }: { token: string }): Humani
           value: {
             id: env.id,
             name: env.name,
+            type: env.type,
+            url: `https://app.humanitec.io/orgs/${orgId}/apps/${appId}/envs/${env.id}`
           }
         })),
       };

--- a/plugins/platform-backend/src/service/router.ts
+++ b/plugins/platform-backend/src/service/router.ts
@@ -28,6 +28,8 @@ import { getDownloadInfo } from '../executables';
 import { GetComponentRef, PlatformApi } from '../types';
 import { Repositories } from './routes/repositories';
 import { Logs } from './routes/logs';
+import CliTable3 from 'cli-table3';
+import chalk from 'chalk';
 
 export interface RouterOptions {
   logger: Logger;
@@ -114,10 +116,14 @@ export async function createRouter(
     let name = req.params.name;
     let ref = await getComponentRef(name);
     if (ref) {
+      const table = new CliTable3({
+        head: ["ID", "Name", "Type", "URL"]
+      });
       let environments = await platform.getEnvironments(ref);
-      let names = environments.items.map(({ value }) => value.name);
-
-      res.send(`${names.join("\n")}\n`);
+      table.push(
+        ...environments.items.map(({ value: r }) => ([r.id, r.name, r.type, r.url ]))
+      )
+      res.send(`\n${chalk.bold('  ☀️ Deployment Environments')}\n${table}\n`);
     } else {
       res.sendStatus(404);
       res.send("Not Found");

--- a/plugins/platform-backend/src/types.ts
+++ b/plugins/platform-backend/src/types.ts
@@ -3,6 +3,8 @@ import type { Entity, CompoundEntityRef } from '@backstage/catalog-model';
 export interface Environment {
   id: string;
   name: string;
+  type: string;
+  url: string;
 }
 
 export interface Repository {


### PR DESCRIPTION
## Motivation

Get better output for `idp environments`

## Approach

- Returning env type and constructing url using [this](https://api-docs.humanitec.com/#tag/Environment/paths/~1orgs~1%7BorgId%7D~1apps~1%7BappId%7D~1envs~1%7BenvId%7D/get)
- Formatting output similarly to `repositories`

<img width="1187" alt="Screen Shot 2022-10-24 at 7 47 09 AM" src="https://user-images.githubusercontent.com/29791650/197519934-a8924790-318d-4d94-984a-0c4fae27b7a9.png">
