### PR TITLE
call build during prepack for @frontside/backstage-plugin-incremental-ingestion-backend

### DIFF
--- a/.changeset/forty-moles-grin.md
+++ b/.changeset/forty-moles-grin.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-incremental-ingestion-backend': patch
+---
+
+call build from prepack in @frontside/backstage-plugin-incremental-ingestion-backend

--- a/plugins/incremental-ingestion-backend/package.json
+++ b/plugins/incremental-ingestion-backend/package.json
@@ -18,7 +18,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
-    "prepack": "backstage-cli package prepack",
+    "prepack": "backstage-cli package prepack && yarn build",
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {


### PR DESCRIPTION
## Motivation

No `dist` folder is getting created for `@frontside/backstage-plugin-incremental-ingestion-backend` during publishing.

## Approach

call `yarn build` during `prepack`.