### PR TITLE
Remove github incremental entity provider

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -42,7 +42,6 @@
     "@frontside/backstage-plugin-humanitec-backend": "^0.3.2",
     "@frontside/backstage-plugin-graphql": "^0.4.2",
     "@frontside/backstage-plugin-incremental-ingestion-backend": "*",
-    "@frontside/backstage-plugin-incremental-ingestion-github": "*",
     "graphql-modules": "^2.1.0",
     "@gitbeaker/node": "^34.6.0",
     "@internal/plugin-healthcheck": "0.1.2",

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -3,9 +3,7 @@ import {
 } from '@backstage/plugin-catalog-backend';
 import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
 import { IncrementalCatalogBuilder } from '@frontside/backstage-plugin-incremental-ingestion-backend';
-import { GithubRepositoryEntityProvider } from '@frontside/backstage-plugin-incremental-ingestion-github';
 import { Router } from 'express';
-import { Duration } from 'luxon';
 import { PluginEnvironment } from '../types';
 
 export default async function createPlugin(
@@ -17,21 +15,6 @@ export default async function createPlugin(
   // incremental entity providers with the builder 
   const incrementalBuilder = await IncrementalCatalogBuilder.create(env, builder);
   
-  const githubRepositoryProvider = GithubRepositoryEntityProvider.create({ 
-    host: 'github.com', 
-    searchQuery: "created:>1970-01-01 user:thefrontside", 
-    config: env.config 
-  })
-
-  incrementalBuilder.addIncrementalEntityProvider(
-    githubRepositoryProvider,
-    {
-      burstInterval: Duration.fromObject({ seconds: 3 }),
-      burstLength: Duration.fromObject({ seconds: 3 }),
-      restLength: Duration.fromObject({ day: 1 })
-    }
-  )
-
   builder.addProcessor(new ScaffolderEntitiesProcessor());
 
   const { processingEngine, router } = await builder.build();


### PR DESCRIPTION
## Motivation

The Incremental Github Entity Provider creates a lot of noise in logs. It was used as a demo; we don't need it for the actual Backstage instance. 

## Approach

Removing `@frontside/backstage-plugin-incremental-ingestion-github` from Backstage backend
