### PR TITLE
Use local files when doing local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
 
 # Then copy the rest of the backend bundle, along with any other files we might want.
-COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./
+COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml catalog-info.yaml templates ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
 
 # Then copy the rest of the backend bundle, along with any other files we might want.
-COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml catalog-info.yaml templates ./
+COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -12,3 +12,12 @@ integrations:
     - host: github.com
       apps:
         - $include: credentials/backstage-app-credentials.yaml
+
+catalog:
+  locations:
+    - type: url
+      target: https://github.com/thefrontside/playhouse/blob/main/catalog-info.yaml
+    - type: url
+      target: https://github.com/thefrontside/playhouse/blob/main/templates/standard-microservice/template.yaml
+      rules:
+        - allow: [Template]

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -79,10 +79,10 @@ scaffolder:
 
 catalog:
   locations:
-    - type: url
-      target: https://github.com/thefrontside/backstage/blob/main/catalog-info.yaml
-    - type: url
-      target: https://github.com/thefrontside/backstage/blob/main/templates/standard-microservice/template.yaml
+    - type: file
+      target: ../../catalog-info.yaml
+    - type: file
+      target: ../../templates/standard-microservice/template.yaml
       rules:
         - allow: [Template]
 


### PR DESCRIPTION
## Motivation

It's annoying that modifying the scaffolder template locally doesn't automatically update the template. This happens because the catalog registers URLs in Github instead of the local file system. I want to make it easier to experiment locally by using local files instead of remote URLs.

## Approach

Move the remote URLs to `app-config.production.yaml` and use local file in production.
