### PR TITLE
catch handler in the IncrementalIngestianEngine is wrongly assuming an error to be a string

### DIFF
--- a/.changeset/bright-rocks-fetch.md
+++ b/.changeset/bright-rocks-fetch.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-incremental-ingestion-backend': patch
+---
+
+catch handler in the IncrementalIngestianEngine is wrongly assuming an error to be a string

--- a/plugins/incremental-ingestion-backend/src/engine/IncrementalIngestionEngine.ts
+++ b/plugins/incremental-ingestion-backend/src/engine/IncrementalIngestionEngine.ts
@@ -102,7 +102,7 @@ export class IncrementalIngestionEngine implements IterationEngine {
               const backoffLength = currentBackoff.as('milliseconds');
               this.options.logger.error(error);
 
-              const truncatedError = (error as string).substring(0, 700);
+              const truncatedError = typeof error === 'string' ? error.substring(0, 700) : `${error}`;
               this.options.logger.error(
                 `incremental-engine: Ingestion '${ingestionId}' threw an error during ingestion burst. Ingestion will backoff for ${currentBackoff.toHuman()} (${truncatedError})`,
               );


### PR DESCRIPTION
## Motivation

catch handler in the `IncrementalIngestianEngine` is wrongly assuming an error to be a string

## Approach

Check string type
