### PR TITLE
Make cursor fields for PageInfo interface optional

### DIFF
--- a/.changeset/tricky-jobs-film.md
+++ b/.changeset/tricky-jobs-film.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql': patch
+---
+
+Make cursor fields for PageInfo interface optional

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -17,8 +17,8 @@ interface Connection @extend {
 interface PageInfo @extend {
   hasNextPage: Boolean!
   hasPreviousPage: Boolean!
-  startCursor: String!
-  endCursor: String!
+  startCursor: String
+  endCursor: String
 }
 
 interface Edge @extend {


### PR DESCRIPTION
## Motivation

`connectionFromArray` function returns object where `pageInfo` field might don't have `startCursor` and `endCursor` fields

## Approach

Make these fields optional