### PR TITLE
Add ability to specify default value for `@field` directive

### DIFF
--- a/.changeset/proud-nails-compare.md
+++ b/.changeset/proud-nails-compare.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql': patch
+---
+
+Add ability to specify default value for `@field` directive

--- a/plugins/graphql/README.md
+++ b/plugins/graphql/README.md
@@ -187,7 +187,7 @@ Every GraphQL API consists of two things - a schema and resolvers. The schema de
 
 #### `@field`
 
-`@field` directive allows you to access properties on the object using a given path. It allows you to specify a resolver for a field from the schema without actually writing a real resolver. Under the hood, it's creating the resolver for you. It's used extensively in the [`catalog.graphql`](https://github.com/thefrontside/backstage/blob/main/plugins/graphql/src/app/modules/catalog/catalog.graphql) module to retrieve properties like `namespace`, `title` and others. For example, here is how we define the resolver for the `Entity#name` field `name: String! @field(at: "metadata.name")`. It also accepts an array of strings, it useful when path tokens contain dots: `label: String! @field(at: ["spec", "data.label"])`.
+`@field` directive allows you to access properties on the object using a given path. It allows you to specify a resolver for a field from the schema without actually writing a real resolver. Under the hood, it's creating the resolver for you. It's used extensively in the [`catalog.graphql`](https://github.com/thefrontside/backstage/blob/main/plugins/graphql/src/app/modules/catalog/catalog.graphql) module to retrieve properties like `namespace`, `title` and others. For example, here is how we define the resolver for the `Entity#name` field `name: String! @field(at: "metadata.name")`. It also accepts an array of strings, it useful when path tokens contain dots: `label: String! @field(at: ["spec", "data.label"])`. You can specify default value as a fallback if the field is not found: `label: String! @field(at: "spec.label", default: "N/A")`.
 
 #### `@relation`
 

--- a/plugins/graphql/src/app/mappers.ts
+++ b/plugins/graphql/src/app/mappers.ts
@@ -90,7 +90,7 @@ export function transformDirectives(sourceSchema: GraphQLSchema) {
     field.resolve = async ({ id }, _, { loader }) => {
       const entity = await loader.load(id);
       if (!entity) return null;
-      return get(entity, directive.at ?? fieldName);
+      return get(entity, directive.at ?? fieldName) ?? directive.default;
     };
   }
 

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,8 +1,9 @@
-directive @field(at: FieldAtArgument) on FIELD_DEFINITION
+directive @field(at: FieldAtArgument, default: FieldDefaultArgument) on FIELD_DEFINITION
 directive @relation(type: String, interface: String, kind: String) on FIELD_DEFINITION
 directive @extend(interface: String, when: ExtendWhenArgument, is: ExtendIsArgument) on INTERFACE
 
 scalar FieldAtArgument
+scalar FieldDefaultArgument
 scalar ExtendWhenArgument
 scalar ExtendIsArgument
 

--- a/plugins/graphql/src/tests/mapper.test.ts
+++ b/plugins/graphql/src/tests/mapper.test.ts
@@ -347,6 +347,7 @@ describe('Transformer', () => {
       interface Entity @extend(interface: "Node") {
         first: String! @field(at: "metadata.name")
         second: String! @field(at: ["spec", "path.to.name"])
+        third: String! @field(at: "nonexisting.path", default: "defaultValue")
       }
       `,
     })
@@ -357,12 +358,13 @@ describe('Transformer', () => {
     const loader = () => new DataLoader(async () => [entity]);
     const query = createGraphQLTestApp(TestModule, loader)
     const result = yield query(/* GraphQL */`
-      node(id: "test") { ...on Entity { first, second } }
+      node(id: "test") { ...on Entity { first, second, third } }
     `)
     expect(result).toEqual({
       node: {
         first: 'hello',
-        second: 'world'
+        second: 'world',
+        third: 'defaultValue',
       }
     })
   })


### PR DESCRIPTION
## Motivation

Sometimes it might be useful to specify default value for required fields in graphql schema, like empty string if there is no value in entity data

## Approach

Added `default` argument for `@field` directive
