### PR TITLE
Remove using field name as a fallback for @relation and @field directives

### DIFF
--- a/.changeset/four-hotels-watch.md
+++ b/.changeset/four-hotels-watch.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql': patch
+---
+
+Remove using field name as a fallback for @relation and @field directives

--- a/plugins/graphql/src/app/modules/catalog/catalog.graphql
+++ b/plugins/graphql/src/app/modules/catalog/catalog.graphql
@@ -47,8 +47,8 @@ interface Component @extend(interface: "Entity", when: "kind", is: "Component") 
   system: System @relation(type: "partOf", kind: "system")
   component: Component @relation(type: "partOf", kind: "component")
   subComponents: Connection @relation(type: "hasPart", interface: "Component")
-  providesApi: Connection @relation(interface: "API")
-  consumesApi: Connection @relation(interface: "API")
+  providesApi: Connection @relation(type: "providesApi", interface: "API")
+  consumesApi: Connection @relation(type: "consumesApi", interface: "API")
   dependencies: Connection @relation(type: "dependsOn", interface: "Dependency")
 }
 
@@ -93,15 +93,15 @@ interface Group @extend(interface: "Entity", when: "kind", is: "Group") {
   parent: Group @relation(type: "childOf")
   children: Connection @relation(type: "parentOf", interface: "Group")
   members: Connection @relation(type: "hasMember", interface: "User")
-  ownerOf: Connection @relation(interface: "Ownable")
+  ownerOf: Connection @relation(type: "ownerOf", interface: "Ownable")
 }
 
 interface User @extend(interface: "Entity", when: "kind", is: "User") {
   displayName: String @field(at: "spec.profile.displayName")
   email: String @field(at: "spec.profile.email")
   picture: String @field(at: "spec.profile.picture")
-  memberOf: Connection @relation(interface: "Group")
-  ownerOf: Connection @relation(interface: "Ownable")
+  memberOf: Connection @relation(type: "memberOf", interface: "Group")
+  ownerOf: Connection @relation(type: "ownerOf", interface: "Ownable")
 }
 
 extend type Query {

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -1,4 +1,4 @@
-directive @field(at: FieldAtArgument) on FIELD_DEFINITION
+directive @field(at: FieldAtArgument!) on FIELD_DEFINITION
 directive @relation(type: String, interface: String, kind: String) on FIELD_DEFINITION
 directive @extend(interface: String, when: ExtendWhenArgument, is: ExtendIsArgument) on INTERFACE
 

--- a/plugins/graphql/src/tests/mapper.test.ts
+++ b/plugins/graphql/src/tests/mapper.test.ts
@@ -377,10 +377,10 @@ describe('Transformer', () => {
         group: Group @relation(type: "ownedBy", kind: "Group")
       }
       interface User @extend(interface: "Node", when: "kind", is: "User") {
-        name: String! @field
+        name: String! @field(at: "name")
       }
       interface Group @extend(interface: "Node", when: "kind", is: "Group") {
-        name: String! @field
+        name: String! @field(at: "name")
       }
       `,
     })
@@ -549,6 +549,73 @@ describe('Transformer', () => {
           { node: { username: 'Team A' } }
         ] },
         groups: { edges: [{ node: { groupname: 'Team B' } }, { node: { groupname: 'Team A' } }] },
+      }
+    })
+  })
+
+  it('resolver for @relation without `type` argument should return all relations', function* () {
+    const TestModule = createModule({
+      id: 'test',
+      typeDefs: gql`
+      interface Entity @extend(interface: "Node", when: "kind", is: "Entity") {
+        assets: [Node] @relation
+      }
+      interface User @extend(interface: "Node", when: "kind", is: "User") {
+        username: String! @field(at: "name")
+      }
+      interface Group @extend(interface: "Node", when: "kind", is: "Group") {
+        groupname: String! @field(at: "name")
+      }
+      interface Component @extend(interface: "Node", when: "kind", is: "Component") {
+        name: String! @field(at: "name")
+      }
+      interface Resource @extend(interface: "Node", when: "kind", is: "Resource") {
+        domain: String! @field(at: "name")
+      }
+      `,
+    })
+    const entity = {
+      kind: 'Entity',
+      relations: [
+        { type: 'partOf', targetRef: 'resource:default/website' },
+        { type: 'hasPart', targetRef: 'component:default/backend' },
+        { type: 'ownedBy', targetRef: 'user:default/john' },
+        { type: 'ownedBy', targetRef: 'group:default/team-b' },
+      ]
+    };
+    const john = { kind: 'User', name: 'John' };
+    const backend = { kind: 'Component', name: 'Backend' };
+    const website = { kind: 'Resource', name: 'example.com' };
+    const teamB = { kind: 'Group', name: 'Team B' };
+    const loader = () => new DataLoader(async (ids) => ids.map(id => {
+      if (id === 'user:default/john') return john
+      if (id === 'component:default/backend') return backend
+      if (id === 'resource:default/website') return website
+      if (id === 'group:default/team-b') return teamB
+      return entity
+    }));
+    const query = createGraphQLTestApp(TestModule, loader)
+    const result = yield query(/* GraphQL */`
+      node(id: "entity") {
+        ...on Entity {
+          assets {
+            id
+            ...on User { username }
+            ...on Group { groupname }
+            ...on Component { name }
+            ...on Resource { domain }
+          }
+        }
+      }
+    `)
+    expect(result).toEqual({
+      node: {
+     assets: [
+         { domain: "example.com", id: "resource:default/website" },
+         { id: "component:default/backend", name: "Backend" },
+         { id: "user:default/john", username: "John" },
+         { groupname: "Team B", id: "group:default/team-b" },
+       ],
       }
     })
   })


### PR DESCRIPTION
## Motivation

Current behavior has confused convention when you declare `@field` directive without `at` argument or `@relation` without `type`. In that case as a fallback for `at/type` is gotten graphql field name. It also makes impossible to use `@relation` for getting all relations no matter what type they are.

## Approach

Remove using field name as a fallback value for `at/type` arguments.
Make `at` argument for `@field` directive required.