### PR TITLE
Make `PageInfo` as an object type instead of interface

### DIFF
--- a/.changeset/new-ants-mate.md
+++ b/.changeset/new-ants-mate.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql': patch
+---
+
+Make `PageInfo` as an object type instead of interface

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -14,7 +14,7 @@ interface Connection @extend {
   total: Int
 }
 
-interface PageInfo @extend {
+type PageInfo {
   hasNextPage: Boolean!
   hasPreviousPage: Boolean!
   startCursor: String!


### PR DESCRIPTION
## Motivation

`react-relay` compiler requires that `pageInfo` field of `Connection` should be an object type. If you try to use an interface you will see this error while building frontend app:
```
[ERROR] Error in the project `default`: ✖︎ @connection used on invalid field 'search'. Expected the field type 'Connection' to expose a 'pageInfo' field that returns an object.
```

## Approach

Make `PageInfo` as an object type
