### PR TITLE
Rename Connection field `total`->`count`

### DIFF
--- a/.changeset/thick-pumpkins-float.md
+++ b/.changeset/thick-pumpkins-float.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql': patch
+---
+
+Rename Connection field `total`->`count`

--- a/plugins/graphql/src/app/mappers.ts
+++ b/plugins/graphql/src/app/mappers.ts
@@ -155,7 +155,10 @@ export function transformDirectives(sourceSchema: GraphQLSchema) {
       field.resolve = async ({ id }, args, { loader, refToId }) => {
         const ids = filterEntityRefs(await loader.load(id), directive.type, directive.kind)
           .map(ref => ({ id: refToId(ref) }));
-        return connectionFromArray(ids, args);
+        return {
+          ...connectionFromArray(ids, args),
+          count: ids.length,
+        };
       };
     } else {
       field.resolve = async ({ id }, _, { loader, refToId }) => {

--- a/plugins/graphql/src/app/modules/core/core.graphql
+++ b/plugins/graphql/src/app/modules/core/core.graphql
@@ -12,7 +12,7 @@ interface Node { id: ID! }
 interface Connection @extend {
   pageInfo: PageInfo!
   edges: [Edge!]!
-  total: Int
+  count: Int
 }
 
 type PageInfo {

--- a/plugins/graphql/src/tests/mapper.test.ts
+++ b/plugins/graphql/src/tests/mapper.test.ts
@@ -79,7 +79,7 @@ describe('Transformer', () => {
       '  foobar: String!',
       '  pageInfo: PageInfo!',
       '  edges: [Edge!]!',
-      '  total: Int',
+      '  count: Int',
       '}'
     ]);
   })
@@ -204,7 +204,7 @@ describe('Transformer', () => {
       'type OwnableConnection implements Connection {',
       '  pageInfo: PageInfo!',
       '  edges: [OwnableEdge!]!',
-      '  total: Int',
+      '  count: Int',
       '}'
     ]);
     expect(printType(schema.getType('User') as GraphQLNamedType).split('\n')).toEqual([
@@ -534,7 +534,7 @@ describe('Transformer', () => {
           ownedBy(first: 2) { edges { node { ...on User { username }, ...on Group { groupname } } } }
           nodes(first: 2, after: "YXJyYXljb25uZWN0aW9uOjE=") { edges { node { ...on Group { groupname }, ...on User { username } } } }
           owners(last: 2) { edges { node { id, ...on User { username } } } }
-          users { edges { node { username } } }
+          users { count, edges { node { username } } }
           groups { edges { node { groupname } } }
         }
       }
@@ -544,12 +544,15 @@ describe('Transformer', () => {
         ownedBy: { edges: [{ node: { username: 'John' } }, { node: { groupname: 'Team B' } }] },
         nodes: { edges: [{ node: { username: 'Mark' } }, { node: { groupname: 'Team A' } }] },
         owners: { edges: [{ node: { id: 'user:default/mark', username: 'Mark' } }, { node: { id: 'group:default/team-a' } }] },
-        users: { edges: [
-          { node: { username: 'John' } },
-          { node: { username: 'Team B' } },
-          { node: { username: 'Mark' } },
-          { node: { username: 'Team A' } }
-        ] },
+        users: {
+          count: 4,
+          edges: [
+            { node: { username: 'John' } },
+            { node: { username: 'Team B' } },
+            { node: { username: 'Mark' } },
+            { node: { username: 'Team A' } }
+          ]
+        },
         groups: { edges: [{ node: { groupname: 'Team B' } }, { node: { groupname: 'Team A' } }] },
       }
     })


### PR DESCRIPTION
## Motivation

`connectionFromArray` returns object that doesn't have `count` or `total` field. It also `count` name is used more often

## Approach

Rename field `total` to `count`. Add it to connection resolvers result