### PR TITLE
[graphql-plugin] Mark some Entity fields required

### DIFF
--- a/.changeset/spicy-hornets-report.md
+++ b/.changeset/spicy-hornets-report.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql': patch
+---
+
+Mark some Entity fields required

--- a/plugins/graphql/src/app/modules/catalog/catalog.graphql
+++ b/plugins/graphql/src/app/modules/catalog/catalog.graphql
@@ -13,9 +13,10 @@ union Owner = User | Group
 
 interface Entity @extend(interface: "Node") {
   name: String! @field(at: "metadata.name")
-  namespace: String @field(at: "metadata.namespace")
-  title: String @field(at: "metadata.title")
-  description: String @field(at: "metadata.description")
+  kind: String! @field(at: "kind")
+  namespace: String! @field(at: "metadata.namespace", default: "default")
+  title: String! @field(at: "metadata.title", default: "")
+  description: String! @field(at: "metadata.description", default: "")
   tags: [String] @field(at: "metadata.tags")
   links: [EntityLink] @field(at: "metadata.links")
 }


### PR DESCRIPTION
## Motivation

If you are using elastic indexing and pushing documents based on your graphql schema. Those documents must have `title`, `description` fields, but according backstage `Entity` type them might be optional.

## Approach

Mark these fields required and added defaults