### PR TITLE
Update readme to use `printSchemaWithDirectives` instead of `printSchema`

### DIFF
--- a/.changeset/kind-hotels-repair.md
+++ b/.changeset/kind-hotels-repair.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql': patch
+---
+
+Update readme to use `printSchemaWithDirectives` instead of `printSchema`

--- a/plugins/graphql/README.md
+++ b/plugins/graphql/README.md
@@ -165,9 +165,9 @@ You can extend the schema from inside of Backstage Backend by creating a [GraphQ
 import { resolvePackagePath } from '@backstage/backend-common';
 import { transformSchema } from '@frontside/backstage-plugin-graphql';
 import { loadFilesSync } from '@graphql-tools/load-files';
-import { printSchema } from 'graphql';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
 
-export default printSchema(
+export default printSchemaWithDirectives(
   transformSchema(
     loadFilesSync(
       resolvePackagePath('backend', 'src/graphql/*.graphql')


### PR DESCRIPTION
## Motivation

`printSchema` from `graphql` outputs schema without directives, as a result, if you use your own directives and custom codegen plugin which utilize those directives, the output schema will not have directives https://github.com/graphql/graphql-js/issues/869

## Approach

Update recommendation to use `printSchemaWithDirectives` from graphql-tools instead