### PR TITLE
add publishConfig to @frontside/backstage-ingestion-tests package.json

### DIFF
--- a/.changeset/great-cows-roll.md
+++ b/.changeset/great-cows-roll.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-ingestion-tests': minor
+---
+
+add publishConfig to @frontside/backstage-ingestion-tests

--- a/packages/ingestion-tests/package.json
+++ b/packages/ingestion-tests/package.json
@@ -10,6 +10,13 @@
     "postpack": "backstage-cli package postpack",
     "clean": "backstage-cli package clean"
   },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
   "backstage": {
     "role": "common-library"
   },


### PR DESCRIPTION
## Motivation

I forgot the backstage `publishConfig` business in the last PR and the `@frontside/backstage-ingestion-tests` package has been published without a dist directory.

## Approach

Add `publishConfig` to the `@frontside/backstage-ingestion-tests` package.json file