### PR TITLE
make the npm script that starts the backstage backend configurable

### DIFF
--- a/.changeset/honest-plants-grin.md
+++ b/.changeset/honest-plants-grin.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-ingestion-tests': minor
+---
+
+createBackstageHarness now takes an npm script to start the backstage process

--- a/packages/ingestion-tests/src/harness.ts
+++ b/packages/ingestion-tests/src/harness.ts
@@ -38,8 +38,11 @@ export interface BackstageHarness {
 
 export function createBackstageHarness(
   factory: Factory,
+  npmScript: string,
   ...configs: JsonObject[]
 ): BackstageHarness {
+  assert(!!npmScript, 'you must supply an npm script e.g. yarn workspace backend start')
+  
   const start = () => ({
     name: 'Backstage',
     *init() {
@@ -97,6 +100,7 @@ export function createBackstageHarness(
       };
 
       const catalog: CatalogApi = yield createBackstage({
+        npmScript,
         config,
         log,
       });

--- a/packages/ingestion-tests/src/support/backstage.ts
+++ b/packages/ingestion-tests/src/support/backstage.ts
@@ -7,6 +7,7 @@ import { CatalogApi, CatalogClient } from '@backstage/catalog-client';
 import { ProcessLog } from './log';
 
 export interface BackstageOptions {
+  npmScript: string;
   log?: boolean | ProcessLog;
   config: JsonObject;
 }
@@ -21,7 +22,7 @@ export function createBackstage(
     labels: { baseUrl: reader.get('backend.baseUrl') },
     *init(_, init) {
       const { JEST_WORKER_ID, ...env } = process.env;
-      const proc: Process = yield daemon('yarn workspace backend start', {
+      const proc: Process = yield daemon(options.npmScript, {
         env: {
           ...env,
           NODE_ENV: 'development',


### PR DESCRIPTION

## Motivation

The `createBackStage` function currently has the npm script that starts the backstage backend hardcoded.


## Approach

`createBackstageHarness` now has a required `npmScript` arg.
