### PR TITLE
bail if the client is no pg in clearTestDatabase

### DIFF
--- a/.changeset/khaki-garlics-poke.md
+++ b/.changeset/khaki-garlics-poke.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-ingestion-tests': patch
+---
+
+bail if the client is no pg in clearTestDatabases

--- a/packages/ingestion-tests/src/support/database.ts
+++ b/packages/ingestion-tests/src/support/database.ts
@@ -5,6 +5,11 @@ import type { JsonValue, JsonObject } from '@backstage/types';
 
 export function* clearTestDatabases(config: JsonObject): Operation<void> {
   const reader = new ConfigReader(config);
+  
+  if (reader.getString('backend.database.client') !== 'pg') {
+    return;
+  }
+
   const dbconfig = reader.get('backend.database');
   const prefix = reader.getString('backend.database.prefix');
 


### PR DESCRIPTION
## Motivation

This is a pretty horrible fix, but I think this whole package needs to be reviewed.  This allows me to drop a dependency on a client project on Postgres and use SQLite which works quite well.

## Approach

check the db client before executing pg specific code in `clearTestDataases`