### PR TITLE
GitHub Auth on Microservice Template

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -7,12 +7,6 @@ backend:
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
 
-integrations:
-  github:
-    - host: github.com
-      apps:
-        - $include: credentials/backstage-app-credentials.yaml
-
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   session:
@@ -29,6 +23,10 @@ auth:
         # if added, we need to update ./charts/backstage/Values.yaml
         # connection: ${AUTH_AUTH0_CONNECTION}
         # connectionScope: ${AUTH_AUTH0_CONNECTION_SCOPE}
+    github:
+      production:
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
 
 catalog:
   locations:

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -7,6 +7,12 @@ backend:
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
 
+integrations:
+  github:
+    - host: github.com
+      apps:
+        - $include: credentials/backstage-app-credentials.yaml
+
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   session:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -60,6 +60,11 @@ techdocs:
   publisher:
     type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
 
+integrations:
+  github:
+    - host: github.com
+      token: ${GITHUB_TOKEN}
+
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   session:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -44,15 +44,6 @@ backend:
     allow:
       - host: localhost:7007
 
-integrations:
-  github:
-    - host: github.com
-      token: ${GITHUB_TOKEN}
-    ### Example for how to add your GitHub Enterprise instance using the API:
-    # - host: ghe.example.net
-    #   apiBaseUrl: https://ghe.example.net/api/v3
-    #   token: ${GHE_TOKEN}
-
 proxy:
   '/test':
     target: 'https://example.com'
@@ -84,6 +75,10 @@ auth:
         clientId: backstage_auth0_client_id
         clientSecret: backstage_auth0_client_secret
         audience: https://frontside-backstage
+    github:
+      development:
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
 
 scaffolder:
   # see https://backstage.io/docs/features/software-templates/configuration for software template options

--- a/charts/backstage/Values.yaml
+++ b/charts/backstage/Values.yaml
@@ -3,6 +3,8 @@ ingressPort: 80
 baseUrl: https://backstage.frontside.services
 # any randomly generated string
 authSessionClientSecret: backstage_auth0_client_secret
+# github scaffolder token
+githubToken: ''
 # auth0 tenant information
 auth0Domain: ''
 auth0ClientId: ''
@@ -12,3 +14,6 @@ auth0Audience: 'https://frontside-backstage'
 #   however empty strings throw a config error
 # auth0Connection:
 # auth0ConnectionScope:
+# github app information
+githubClientId: ''
+githubClientSecret: ''

--- a/charts/backstage/templates/configmap.yaml
+++ b/charts/backstage/templates/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
 data:
   APP_CONFIG_app_baseUrl: {{ .Values.baseUrl }}
   APP_CONFIG_backend_baseUrl: {{ .Values.baseUrl }}
+  # auth0 config
   AUTH_AUTH0_DOMAIN: {{ required "You must provide a Auth0 Domain" .Values.auth0Domain }}
   AUTH_AUTH0_CLIENT_ID: {{ required "You must provide a Auth0 Client ID" .Values.auth0ClientId }}
   AUTH_AUTH0_AUDIENCE: {{ .Values.auth0Audience }}
@@ -12,3 +13,5 @@ data:
   #   however empty strings throw a config error
   # AUTH_AUTH0_CONNECTION: {{ .Values.auth0Connection }}
   # AUTH_AUTH0_CONNECTION_SCOPE: {{ .Values.auth0ConnectionScope }}
+  # github auth config
+  AUTH_GITHUB_CLIENT_ID: {{ required "You must provide a Github App Client ID" .Values.githubClientId }}

--- a/charts/backstage/templates/secrets.yaml
+++ b/charts/backstage/templates/secrets.yaml
@@ -15,3 +15,4 @@ data:
   AUTH_SESSION_CLIENT_SECRET: {{ required "You must provide a Auth Session Client Secret" .Values.authSessionClientSecret | b64enc}}
   HUMANITEC_TOKEN: {{ required "You must provide a Humanitec token" .Values.humanitecToken | b64enc}}
   AUTH_AUTH0_CLIENT_SECRET: {{ required "You must provide a Auth0 Client Secret" .Values.auth0ClientSecret | b64enc}}
+  AUTH_GITHUB_CLIENT_SECRET: {{ required "You must provide a Github Client Secret" .Values.githubClientSecret | b64enc}}

--- a/charts/backstage/templates/secrets.yaml
+++ b/charts/backstage/templates/secrets.yaml
@@ -11,7 +11,7 @@ metadata:
   name: backstage-secrets
 type: Opaque
 data:
-  GITHUB_TOKEN: {{ required "You must provide a Auth Session Client Secret" .Values.githubToken | b64enc}}
+  GITHUB_TOKEN: {{ required "You must provide a Github Token to read private repositories" .Values.githubToken | b64enc}}
   AUTH_SESSION_CLIENT_SECRET: {{ required "You must provide a Auth Session Client Secret" .Values.authSessionClientSecret | b64enc}}
   HUMANITEC_TOKEN: {{ required "You must provide a Humanitec token" .Values.humanitecToken | b64enc}}
   AUTH_AUTH0_CLIENT_SECRET: {{ required "You must provide a Auth0 Client Secret" .Values.auth0ClientSecret | b64enc}}

--- a/charts/backstage/templates/secrets.yaml
+++ b/charts/backstage/templates/secrets.yaml
@@ -11,6 +11,7 @@ metadata:
   name: backstage-secrets
 type: Opaque
 data:
+  GITHUB_TOKEN: {{ required "You must provide a Auth Session Client Secret" .Values.githubToken | b64enc}}
   AUTH_SESSION_CLIENT_SECRET: {{ required "You must provide a Auth Session Client Secret" .Values.authSessionClientSecret | b64enc}}
   HUMANITEC_TOKEN: {{ required "You must provide a Humanitec token" .Values.humanitecToken | b64enc}}
   AUTH_AUTH0_CLIENT_SECRET: {{ required "You must provide a Auth0 Client Secret" .Values.auth0ClientSecret | b64enc}}

--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
   "resolutions": {
     "@types/react": "^17",
     "@types/react-dom": "^17",
-    "@codemirror/language": "^6.0.0",
-    "@codemirror/legacy-modes": "^6.1.0",
-    "@codemirror/view": "^6.0.0",
     "graphql": "^16.5.0"
   },
   "prettier": "@spotify/prettier-config",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -48,15 +48,12 @@ const app = createApp({
     SignInPage: props => (
       <SignInPage
         {...props}
-        providers={[
-          'guest',
-          {
-            id: 'auth0-auth-provider',
-            title: 'Auth0',
-            message: 'Sign in using Auth0',
-            apiRef: auth0AuthApiRef,
-          },
-        ]}
+        provider={{
+          id: 'auth0-auth-provider',
+          title: 'Auth0',
+          message: 'Sign in using Auth0',
+          apiRef: auth0AuthApiRef,
+        }}
       />
     ),
   },
@@ -117,12 +114,12 @@ const routes = (
         <UserSettingsPage
           providerSettings={
             <>
-            <ProviderSettingsItem
-              title="Auth0"
-              description="Provides sign-in via Auth0"
-              apiRef={auth0AuthApiRef}
-              icon={Star}
-            />
+              <ProviderSettingsItem
+                title="Auth0"
+                description="Provides sign-in via Auth0"
+                apiRef={auth0AuthApiRef}
+                icon={Star}
+              />
               <ProviderSettingsItem
                 title="GitHub"
                 description="Provides authentication towards GitHub APIs"

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -40,6 +40,7 @@ import { GraphiQLPage } from '@backstage/plugin-graphiql';
 import { SignInPage } from '@backstage/core-components';
 import { auth0AuthApiRef } from './internal';
 import Star from '@material-ui/icons/Star';
+import { githubAuthApiRef } from '@backstage/core-plugin-api';
 
 const app = createApp({
   apis,
@@ -115,12 +116,20 @@ const routes = (
       element={
         <UserSettingsPage
           providerSettings={
+            <>
             <ProviderSettingsItem
               title="Auth0"
               description="Provides sign-in via Auth0"
               apiRef={auth0AuthApiRef}
               icon={Star}
             />
+              <ProviderSettingsItem
+                title="GitHub"
+                description="Provides authentication towards GitHub APIs"
+                apiRef={githubAuthApiRef}
+                icon={Star}
+              />
+            </>
           }
         />
       }

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -1,8 +1,8 @@
 import {
-  DEFAULT_NAMESPACE,
-  stringifyEntityRef,
-} from '@backstage/catalog-model';
-import { createRouter, providers } from '@backstage/plugin-auth-backend';
+  createRouter,
+  providers,
+  defaultAuthProviderFactories,
+} from '@backstage/plugin-auth-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 
@@ -20,6 +20,7 @@ export default async function createPlugin({
     discovery,
     tokenManager,
     providerFactories: {
+      ...defaultAuthProviderFactories,
       auth0: providers.auth0.create({
         signIn: {
           resolver: async ({ profile }, ctx) => {

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -1,3 +1,4 @@
+import { stringifyEntityRef } from '@backstage/catalog-model';
 import {
   createRouter,
   providers,
@@ -42,10 +43,7 @@ export default async function createPlugin({
 
             // Next we verify the email domain. It is recommended to include this
             // kind of check if you don't look up the user in an external service.
-            if (
-              domain !== 'frontside.com' &&
-              config.getString('auth.environment') === 'production'
-            ) {
+            if (domain !== 'frontside.com') {
               throw new Error(
                 `Login failed, this email ${profile.email} does not belong to the expected domain`,
               );
@@ -55,7 +53,7 @@ export default async function createPlugin({
             const userEntity = stringifyEntityRef({
               kind: 'User',
               name,
-              namespace: DEFAULT_NAMESPACE,
+              namespace: 'frontside',
             });
             return ctx.issueToken({
               claims: {

--- a/packages/simulation/bin/start.mjs
+++ b/packages/simulation/bin/start.mjs
@@ -9,10 +9,10 @@ main(function* () {
   const serviceURL = new URL('https://localhost:4400');
   const people = [
     {
-      id: 'paulwaters',
-      name: 'Paul Waters',
+      id: 'testuser',
+      name: 'Test User',
       password: 'password',
-      email: 'paulwaters@placeholder.com',
+      email: 'test@frontside.com',
       picture: faker.image.avatar(),
     },
   ];

--- a/templates/standard-microservice/template.yaml
+++ b/templates/standard-microservice/template.yaml
@@ -12,6 +12,7 @@ spec:
       required:
         - repoUrl
         - componentName
+        - visibility
       properties:
         componentName: # for catalog metadata, description of the repo, used for "repo" of octokit (must match what goes into repourl)
           title: Component Name
@@ -35,6 +36,13 @@ spec:
               - github.com
             allowedOwners:
               - thefrontside
+        visibility:
+          title: Repo Visibility
+          type: string
+          enum:
+            - public
+            - private
+          description: The repository visibility on Github
 
   steps:
     - name: Read Environment
@@ -60,6 +68,8 @@ spec:
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: main
         token: ${{ secrets.USER_OAUTH_TOKEN }}
+        repoVisibility: ${{ parameters.visibility }}
+        hasWiki: false
     - name: Create Humanitec App
       id: humanitec-create-app
       action: humanitec:create-app
@@ -71,3 +81,11 @@ spec:
       input:
         repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
+
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps['publish'].output.remoteUrl }} # link to the remote repository
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }} # link to the entity that has been ingested to the catalog

--- a/templates/standard-microservice/template.yaml
+++ b/templates/standard-microservice/template.yaml
@@ -25,8 +25,17 @@ spec:
           type: string
           ui:field: RepoUrlPicker
           ui:options:
+            # https://backstage.io/docs/features/software-templates/writing-templates#using-the-users-oauth-token
+            requestUserCredentials:
+              secretsKey: USER_OAUTH_TOKEN
+              additionalScopes:
+                github:
+                  - workflow
             allowedHosts:
               - github.com
+            allowedOwners:
+              - thefrontside
+
   steps:
     - name: Read Environment
       id: environment
@@ -49,6 +58,8 @@ spec:
         allowedHosts: ['github.com']
         description: Created from a Standard Microservice template
         repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: main
+        token: ${{ secrets.USER_OAUTH_TOKEN }}
     - name: Create Humanitec App
       id: humanitec-create-app
       action: humanitec:create-app

--- a/yarn.lock
+++ b/yarn.lock
@@ -4297,17 +4297,7 @@
     "@codemirror/view" "^6.0.0"
     "@lezer/common" "^1.0.0"
 
-"@codemirror/commands@^6.0.0":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.0.1.tgz#c005dd2dab2f6d90ad00d4a25bfeaaec2393efa6"
-  integrity sha512-iNHDByicYqQjs0Wo1MKGfqNbMYMyhS9WV6EwMVwsHXImlFemgEUC+c5X22bXKBStN3qnwg4fArNZM+gkv22baQ==
-  dependencies:
-    "@codemirror/language" "^6.0.0"
-    "@codemirror/state" "^6.0.0"
-    "@codemirror/view" "^6.0.0"
-    "@lezer/common" "^1.0.0"
-
-"@codemirror/commands@^6.1.0":
+"@codemirror/commands@6.1.1", "@codemirror/commands@^6.0.0", "@codemirror/commands@^6.1.0":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.1.1.tgz#f92a343f53f4ecff10fc1f4114d0c9e49e7715b7"
   integrity sha512-ibDohwkk7vyu3VsnZNlQhwk0OETBtlkYV+6AHfn5Zgq0sxa+yGVX+apwtC3M4wh6AH7yU5si/NysoECs5EGS3Q==
@@ -4354,12 +4344,7 @@
     "@codemirror/view" "^6.0.0"
     crelt "^1.0.5"
 
-"@codemirror/state@^6.0.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.0.tgz#c0f1d80f61908c9dcf5e2a3fe931e9dd78f3df8a"
-  integrity sha512-qbUr94DZTe6/V1VS7LDLz11rM/1t/nJxR1El4I6UaxDEdc0aZZvq6JCLJWiRmUf95NRAnDH6fhXn+PWp9wGCIg==
-
-"@codemirror/state@^6.1.1":
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.1.1":
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.2.tgz#182d46eabcc17c95508984d6add5a5a641dcd517"
   integrity sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA==


### PR DESCRIPTION
## Motivation

The microservice template should use the logged in user's GitHub auth to create the repository as this better respects the permission system in place.

## Approach

Adjusted the auth options to better expose GitHub, and wire up the template with it.
