### PR TITLE
enable auth for the endpoints with support

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -17,6 +17,9 @@ auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   session:
     secret: ${AUTH_SESSION_CLIENT_SECRET}
+  # see https://backstage.io/docs/auth/service-to-service-auth#setup
+  keys:
+    - secret: ${BACKEND_SECRET}
   environment: production
   providers:
     auth0:

--- a/packages/app/src/cookieAuth.ts
+++ b/packages/app/src/cookieAuth.ts
@@ -1,0 +1,53 @@
+import type { IdentityApi } from '@backstage/core-plugin-api';
+
+// Parses supplied JWT token and returns the payload
+function parseJwt(token: string): { exp: number } {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split('')
+      .map(
+        c =>
+          // eslint-disable-next-line prefer-template
+          '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2),
+      )
+      .join(''),
+  );
+
+  return JSON.parse(jsonPayload);
+}
+
+// Returns milliseconds until the supplied JWT token expires
+function msUntilExpiry(token: string): number {
+  const payload = parseJwt(token);
+  const remaining =
+    new Date(payload.exp * 1000).getTime() - new Date().getTime();
+  return remaining;
+}
+
+// Calls the specified url regularly using an auth token to set a token cookie
+// to authorize regular HTTP requests when loading techdocs
+export async function setTokenCookie(url: string, identityApi: IdentityApi) {
+  const { token } = await identityApi.getCredentials();
+  if (!token) {
+    return;
+  }
+
+  await fetch(url, {
+    mode: 'cors',
+    credentials: 'include',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  // Call this function again a few minutes before the token expires
+  const ms = msUntilExpiry(token) - 4 * 60 * 1000;
+  setTimeout(
+    () => {
+      setTokenCookie(url, identityApi);
+    },
+    ms > 0 ? ms : 10000,
+  );
+}

--- a/packages/backend/src/authMiddleware.ts
+++ b/packages/backend/src/authMiddleware.ts
@@ -1,0 +1,71 @@
+import type { Config } from '@backstage/config';
+import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
+// this dep is required in @backstage/plugin-auth-node, but it doesn't export this functionality
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { decodeJwt } from 'jose';
+import { NextFunction, Request, Response, RequestHandler } from 'express';
+import { URL } from 'url';
+import { PluginEnvironment } from './types';
+
+function setTokenCookie(
+  res: Response,
+  options: { token: string; secure: boolean; cookieDomain: string },
+) {
+  try {
+    const payload = decodeJwt(options.token);
+    res.cookie('token', options.token, {
+      expires: new Date(payload.exp ? payload.exp * 1000 : 0),
+      secure: options.secure,
+      sameSite: 'lax',
+      domain: options.cookieDomain,
+      path: '/',
+      httpOnly: true,
+    });
+  } catch (_err) {
+    // Ignore
+  }
+}
+
+export const createAuthMiddleware = async (
+  config: Config,
+  appEnv: PluginEnvironment,
+) => {
+  const baseUrl = config.getString('backend.baseUrl');
+  const secure = baseUrl.startsWith('https://');
+  const cookieDomain = new URL(baseUrl).hostname;
+  const authMiddleware: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    try {
+      const token =
+        getBearerTokenFromAuthorizationHeader(req.headers.authorization) ||
+        (req.cookies?.token as string | undefined);
+      if (!token) {
+        res.status(401).send('Unauthorized');
+        return;
+      }
+      try {
+        req.user = await appEnv.identity.getIdentity({ request: req });
+      } catch {
+        await appEnv.tokenManager.authenticate(token);
+      }
+      if (!req.headers.authorization) {
+        // Authorization header may be forwarded by plugin requests
+        req.headers.authorization = `Bearer ${token}`;
+      }
+      if (token && token !== req.cookies?.token) {
+        setTokenCookie(res, {
+          token,
+          secure,
+          cookieDomain,
+        });
+      }
+      next();
+    } catch (error) {
+      res.status(401).send('Unauthorized');
+    }
+  };
+  return authMiddleware;
+};


### PR DESCRIPTION
## Motivation

Each endpoint must support the IdentityApi. We have a few custom plugins which do not yet appear to support it. This enables auth on any of the endpoints that appear to support it.

I think this should land after #185, but I don't believe it technically matters.

## Approach

Add an `authMiddleware.ts` and `cookieAuth` as per the [community docs](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md).
