### PR TITLE
use gke-gcloud-auth-plugin for longer-lived token

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
+        with:
+          install_components: gke-gcloud-auth-plugin
 
       - name: Install/Build Backstage
         run: yarn && yarn tsc && yarn build
@@ -54,8 +56,9 @@ jobs:
       - name: Authenticate to GKE Cluster
         uses: google-github-actions/get-gke-credentials@v1
         with:
-          cluster_name: 'backstage-cluster'
-          location: 'northamerica-northeast1-a'
+          cluster_name: backstage-cluster
+          location: northamerica-northeast1-a
+          use_auth_provider: true
 
       - name: Helm Upgrade Postgres
         run: |-


### PR DESCRIPTION
## Motivation

We swapped to an action to auth and used the `short-lived` token option in #189. After merging, we ran into the error in our charts that the `$AUTH_SESSION_CLIENT_SECRET` env var was not set.

## Approach

I am guessing that this was set as part of our previous credential steps, and that the short-lived token option doesn't set this. This seems to be the only other thing we can tweak, so educated guess that this option will enable the option that sets this env var.

Based on information within https://github.com/google-github-actions/setup-gcloud/issues/561.
