### PR TITLE
set USE_GKE_GCLOUD_AUTH_PLUGIN env to use gcloud auth plugin in deploy process

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,7 @@ concurrency: ${{ github.ref }}
 
 env:
   IMAGE: 'northamerica-northeast1-docker.pkg.dev/frontside-backstage/frontside-artifacts/backstage'
+  USE_GKE_GCLOUD_AUTH_PLUGIN: true
 
 jobs:
   deploy:


### PR DESCRIPTION
## Motivation

As part of #190, we swapped to use the auth plugin. It seems that we may have missed the env var to enable the `gcloud` CLI to actually use it as [noted in this comment](https://github.com/google-github-actions/setup-gcloud/issues/561#issuecomment-1357734271).
