### PR TITLE
add AUTH_SESSION_CLIENT_SECRET secret to envs on docker build

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -82,6 +82,7 @@ jobs:
         env:
           CREDENTIALS: ${{ secrets.BACKSTAGE_GITHUB_APP_CREDENTIALS }}
           HUMANITEC_TOKEN: ${{ secrets.HUMANITEC_TOKEN }}
+          AUTH_SESSION_CLIENT_SECRET: ${{ secrets.AUTH_SESSION_CLIENT_SECRET }}
 
       - name: Confirm Deployment Status
         id: deploy-status


### PR DESCRIPTION
## Motivation

We added the `AUTH_SESSION_CLIENT_SECRET` for session support, but it did not add it to the envs that we push to docker in the deploy step. This was originally hidden by other error that we might have resolved in #189.
