### PR TITLE
only specify auth0 args in k8s config planned for use

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -85,7 +85,7 @@ jobs:
           HUMANITEC_TOKEN: ${{ secrets.HUMANITEC_TOKEN }}
           AUTH_SESSION_CLIENT_SECRET: ${{ secrets.AUTH_SESSION_CLIENT_SECRET }}
           AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
-          # matches required in ./charts/backstage/templates/configmap.yaml
+          # matches required in ./charts/backstage/configmap.yaml
           AUTH0_DOMAIN_ID: ${{ secrets.AUTH0_DOMAIN_ID }}
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
 

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -21,12 +21,14 @@ auth:
   providers:
     auth0:
       production:
-        domain: ${AUTH_AUTH0_DOMAIN_ID}
+        domain: ${AUTH_AUTH0_DOMAIN}
         clientId: ${AUTH_AUTH0_CLIENT_ID}
         clientSecret: ${AUTH_AUTH0_CLIENT_SECRET}
         audience: ${AUTH_AUTH0_AUDIENCE}
-        connection: ${AUTH_AUTH0_CONNECTION}
-        connectionScope: ${AUTH_AUTH0_CONNECTION_SCOPE}
+        # these are optional, and we are using the defaults
+        # if added, we need to update ./charts/backstage/Values.yaml
+        # connection: ${AUTH_AUTH0_CONNECTION}
+        # connectionScope: ${AUTH_AUTH0_CONNECTION_SCOPE}
 
 catalog:
   locations:

--- a/charts/backstage/Values.yaml
+++ b/charts/backstage/Values.yaml
@@ -2,11 +2,13 @@ backstagePort: 7007
 ingressPort: 80
 baseUrl: https://backstage.frontside.services
 # any randomly generated string
-authSessionClientSecret: abcde
-# auth0 client secret
-auth0ClientSecret:
-auth0DomainId:
-auth0ClientId: 
-auth0Audience: 
-auth0Connection: 
-auth0ConnectionScope: 
+authSessionClientSecret: backstage_auth0_client_secret
+# auth0 tenant information
+auth0Domain: ''
+auth0ClientId: ''
+auth0ClientSecret: ''
+auth0Audience: 'https://frontside-backstage'
+# these are optional, and we are using the defaults
+#   however empty strings throw a config error
+# auth0Connection:
+# auth0ConnectionScope:

--- a/charts/backstage/templates/secrets.yaml
+++ b/charts/backstage/templates/secrets.yaml
@@ -11,6 +11,6 @@ metadata:
   name: backstage-secrets
 type: Opaque
 data:
-  HUMANITEC_TOKEN: {{ required "You must provide a Humanitec token" .Values.humanitecToken | b64enc}}
   AUTH_SESSION_CLIENT_SECRET: {{ required "You must provide a Auth Session Client Secret" .Values.authSessionClientSecret | b64enc}}
+  HUMANITEC_TOKEN: {{ required "You must provide a Humanitec token" .Values.humanitecToken | b64enc}}
   AUTH_AUTH0_CLIENT_SECRET: {{ required "You must provide a Auth0 Client Secret" .Values.auth0ClientSecret | b64enc}}


### PR DESCRIPTION
## Motivation

We receive config errors if auth0 config values are specified as undefined, and cannot have an empty (`nil`) value in yaml.

## Approach

Splitting hairs around here and only specifying the config values that we need to use, and not setting the optional one at all. I also updated the config in our repo secrets as well.
