### PR TITLE
auth0_domain_id changed to remove _id

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -77,7 +77,7 @@ jobs:
             --set humanitecToken="$HUMANITEC_TOKEN" \
             --set authSessionClientSecret="$AUTH_SESSION_CLIENT_SECRET" \
             --set auth0ClientSecret="$AUTH0_CLIENT_SECRET" \
-            --set auth0DomainId="$AUTH0_DOMAIN_ID" \
+            --set auth0Domain="$AUTH0_DOMAIN" \
             --set auth0ClientId="$AUTH0_CLIENT_ID"
         env:
           CREDENTIALS: ${{ secrets.BACKSTAGE_GITHUB_APP_CREDENTIALS }}
@@ -86,7 +86,7 @@ jobs:
           AUTH_SESSION_CLIENT_SECRET: ${{ secrets.AUTH_SESSION_CLIENT_SECRET }}
           AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
           # matches required in ./charts/backstage/configmap.yaml
-          AUTH0_DOMAIN_ID: ${{ secrets.AUTH0_DOMAIN_ID }}
+          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
 
       - name: Confirm Deployment Status

--- a/charts/backstage/templates/configmap.yaml
+++ b/charts/backstage/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   APP_CONFIG_app_baseUrl: {{ .Values.baseUrl }}
   APP_CONFIG_backend_baseUrl: {{ .Values.baseUrl }}
-  AUTH_AUTH0_DOMAIN_ID: {{ required "You must provide a Auth0 Domain ID" .Values.auth0DomainId }}
+  AUTH_AUTH0_DOMAIN: {{ required "You must provide a Auth0 Domain" .Values.auth0Domain }}
   AUTH_AUTH0_CLIENT_ID: {{ required "You must provide a Auth0 Client ID" .Values.auth0ClientId }}
   AUTH_AUTH0_AUDIENCE: {{ .Values.auth0Audience }}
   AUTH_AUTH0_CONNECTION: {{ .Values.auth0Connection }}


### PR DESCRIPTION
## Motivation

I changed the `AUTH0_DOMAIN_ID` to remove the `_ID` as it is a URL. I missed updating the pass through config.

## Approach

Remove the `ID` from each of these locations.
