### PR TITLE
configmap cannot have nil values either

### DIFF
--- a/charts/backstage/templates/configmap.yaml
+++ b/charts/backstage/templates/configmap.yaml
@@ -8,5 +8,7 @@ data:
   AUTH_AUTH0_DOMAIN: {{ required "You must provide a Auth0 Domain" .Values.auth0Domain }}
   AUTH_AUTH0_CLIENT_ID: {{ required "You must provide a Auth0 Client ID" .Values.auth0ClientId }}
   AUTH_AUTH0_AUDIENCE: {{ .Values.auth0Audience }}
-  AUTH_AUTH0_CONNECTION: {{ .Values.auth0Connection }}
-  AUTH_AUTH0_CONNECTION_SCOPE: {{ .Values.auth0ConnectionScope }}
+  # these are optional, and we are using the defaults
+  #   however empty strings throw a config error
+  # AUTH_AUTH0_CONNECTION: {{ .Values.auth0Connection }}
+  # AUTH_AUTH0_CONNECTION_SCOPE: {{ .Values.auth0ConnectionScope }}


### PR DESCRIPTION
## Motivation

In trying to leave a little bit of dynamic config, we still end up passing a `nil` to the configmap Auth0 connection info. Technically we want this from the backstage perspective, but k8s is not happy about it. Comment it out as the dynamicism isn't really providing enough value to work it out.
