### PR TITLE
annotate k8s config and secrets to trigger updates

### DIFF
--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       app: backstage
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/templates/configmap.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/templates/secrets.yaml") . | sha256sum }}
       labels:
         app: backstage
     spec:


### PR DESCRIPTION
## Motivation

When our configmaps or secrets change, we did not have a way to trigger the `helm upgrade` to also bump those in our cluster. This annotation should, I believe, make that bump happen. It won't allow us to change secrets or config out of band / without a deployment (and that sha changing), but any change in either of these files will change the sha and trigger a bump.
