### PR TITLE
deployment template is based on deployment.yaml path

### DIFF
--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -16,8 +16,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/templates/configmap.yaml") . | sha256sum }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/templates/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
         app: backstage
     spec:


### PR DESCRIPTION
## Motivation

The pathing for deployment that the path was incorrect. The `BasePath` was deeper than I expected. Remove a `/templates` dir.

```
Error: UPGRADE FAILED: template: backstage-mincharts/templates/deployment.yaml:19:28: executing "backstage-mincharts/templates/deployment.yaml" at <include (print $.Template.BasePath "/templates/configmap.yaml") .>: error calling include: template: no template "backstage-mincharts/templates/templates/configmap.yaml" associated with template "gotpl"
```
