### PR TITLE
temp move back to old cloudbuild

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
 concurrency: ${{ github.ref }}
 
 env:
-  IMAGE: 'northamerica-northeast1-docker.pkg.dev/frontside-humanitec/frontside-artifacts/backstage'
+  IMAGE: 'northamerica-northeast1-docker.pkg.dev/frontside-backstage/frontside-artifacts/backstage'
   USE_GKE_GCLOUD_AUTH_PLUGIN: true
 
 jobs:


### PR DESCRIPTION
## Motivation

The cloudbuild uses a Workload Identity Pools to auth, which is a non-trivial amount of effort to shift over. Punt on it for now until we get other, more important, items in place.
