### PR TITLE
set backend_secret in config

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -1,4 +1,7 @@
 backend:
+  auth:
+    keys:
+      - secret: ${AUTH_BACKEND_SECRET}
   database:
     client: pg
     connection:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -8,9 +8,9 @@ organization:
 backend:
   # Used for enabling authentication, secret is shared by all backend plugins
   # See backend-to-backend-auth.md in the docs for information on the format
-  # auth:
-  #   keys:
-  #     - secret: ${BACKEND_SECRET}
+  auth:
+    keys:
+      - secret: backstage_auth_backend_secret
   baseUrl: http://localhost:7007
   listen:
     port: 7007
@@ -68,7 +68,7 @@ integrations:
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   session:
-    secret: backstage_auth0_client_secret
+    secret: backstage_auth_session_secret
   environment: development
   providers:
     auth0:


### PR DESCRIPTION
## Motivation

The backend secret is used for enabling authentication, secret is shared by all backend plugins. It wasn't enabled as part of the previous auth PRs.

## Approach

Enable it and set it in the Humanitec secrets.
