### PR TITLE
use the frontsidejack token for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: volta-cli/action@v3
-      # Installing yarn globaly so the workflow will work in `act`
-      - run: npm install --global yarn
       - run: yarn install --frozen-lockfile # optional, --immutable
       - run: yarn tsc
       - run: docker-compose up &

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,3 +16,5 @@ jobs:
       - run: yarn tsc
       - run: docker-compose up &
       - run: yarn test
+        env:
+          GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

Using this token instead should make certain that our tests don't accidentally blitz the default runner token and consequently through odd errors.
