### PR TITLE
add 1Password credential injection as a local config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,23 @@ yarn dev
 
 ## Running with simulation
 
-We're using the [Auth0 Simulator](https://www.npmjs.com/package/@simulacrum/auth0-simulator) for local development. 
+We're using the [Auth0 Simulator](https://www.npmjs.com/package/@simulacrum/auth0-simulator) for local development.
 
 It's automatically started by `yarn dev`.
 
 Keep an eye for user information in the log output.
 
 ![Log output with user information](https://user-images.githubusercontent.com/74687/199505266-1519969d-d5b3-4f4a-93a0-943b47d0d13b.jpg)
+
+## Running with production config
+
+Running with simulation should be used in most situations. However, there are times where using the production config is necessary to debug, e.g. specific Auth0 configuration issues.
+
+With access to the Frontside 1Password vault and the [1Password CLI](https://developer.1password.com/docs/cli/), you may inject the secrets into a `.gitignore`d config file and use the `yarn dev:config` command to pick up these values.
+
+```
+op inject -i app-config.1password.yaml.tpl -o app-config-credentials.yaml
+```
 
 ## Running in minikube
 

--- a/app-config.1password.yaml.tpl
+++ b/app-config.1password.yaml.tpl
@@ -1,0 +1,26 @@
+# 1Password vault replace syntax
+#-op://vault-name/item-name/[section-name/]field-name
+
+integrations:
+  github:
+    - host: github.com
+      token: {{ op://private/Backstage Github PAT/password }}
+
+auth:
+  environment: development
+  providers:
+    auth0:
+      development:
+        domain: {{ op://shared/Backstage Auth0/production/domain }}
+        clientId: {{ op://shared/Backstage Auth0/production/client_id }}
+        clientSecret: {{ op://shared/Backstage Auth0/production/client_secret }}
+        audience: {{ op://shared/Backstage Auth0/production/audience }}
+    github:
+      development:
+        clientId: {{ op://shared/Backstage - GitHub oAuth App/localhost/client id }}
+        clientSecret: {{ op://shared/Backstage - GitHub oAuth App/localhost/client secret }}
+
+humanitec:
+  orgId: the-frontside-software-inc
+  registryUrl: 'northamerica-northeast1-docker.pkg.dev/frontside-backstage/frontside-artifacts'
+  token: {{ op://shared/Humanitec Token/credential }}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "dev": "concurrently \"yarn start\" \"yarn start-backend\" \"yarn start-sim\"",
+    "dev:config": "concurrently \"yarn start --config ../../app-config.yaml --config ../../app-config-credentials.yaml\" \"yarn start-backend --config ../../app-config.yaml --config ../../app-config-credentials.yaml\"",
     "start": "yarn workspace app start",
     "start-backend": "yarn workspace backend start",
     "start-sim": "yarn workspace simulation watch",


### PR DESCRIPTION
## Motivation

Running with simulation should be used in most situations. However, there are times where using the production config is necessary to debug, e.g. specific Auth0 configuration issues.

With access to the Frontside 1Password vault and the [1Password CLI](https://developer.1password.com/docs/cli/), you may inject the secrets into a `.gitignore`d config file and use the `yarn dev:config` command to pick up these values.

## Approach

Added a template file that the 1Password CLI can use, and a root command that start Backstage with these credentials.

### Alternate Designs

We discussed PlatformScript better enabling this use case, but it requires some implementation and this shall serve as a good concrete example we can use to build towards.
