### PR TITLE
offline_access in auth0 default scope

### DIFF
--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -36,7 +36,7 @@ export const apis: AnyApiFactory[] = [
           title: 'Auth0',
           icon: () => null,
         },
-        defaultScopes: ['openid', 'email', 'profile'],
+        defaultScopes: ['openid', 'email', 'profile', 'offline_access'],
         environment: configApi.getOptionalString('auth.environment'),
       }),
   }),


### PR DESCRIPTION
## Motivation

At minimum, it seems that a refresh token requires the `offline_access` scope which we were not setting in our auth flow. Add it to the list.

## Approach

We were getting an `Unauthorized` on the refresh call. It doesn't appear related to other auth issues, but this seems that we would want to enable regardless.
