### PR TITLE
need production, remove audience

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -20,20 +20,20 @@ auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   session:
     secret: ${AUTH_SESSION_CLIENT_SECRET}
-  environment: development
+  environment: production
   providers:
     auth0:
-      development:
+      production:
         domain: ${AUTH_AUTH0_DOMAIN}
         clientId: ${AUTH_AUTH0_CLIENT_ID}
         clientSecret: ${AUTH_AUTH0_CLIENT_SECRET}
-        audience: ${AUTH_AUTH0_AUDIENCE}
+        # audience: ${AUTH_AUTH0_AUDIENCE}
         # these are optional, and we are using the defaults
         # if added, we need to update ./charts/backstage/Values.yaml
         # connection: ${AUTH_AUTH0_CONNECTION}
         # connectionScope: ${AUTH_AUTH0_CONNECTION_SCOPE}
     github:
-      development:
+      production:
         clientId: ${AUTH_GITHUB_CLIENT_ID}
         clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
 

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -79,7 +79,7 @@ auth:
         domain: localhost:4400
         clientId: backstage_auth0_client_id
         clientSecret: backstage_auth0_client_secret
-        audience: https://frontside-backstage
+        # audience: https://frontside-backstage
     github:
       development:
         clientId: ${AUTH_GITHUB_CLIENT_ID}


### PR DESCRIPTION
## Motivation

The auth seems to default to production so rolling that back. Checking without the audience though.
