### PR TITLE
re-enable the audience in auth0

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -27,7 +27,7 @@ auth:
         domain: ${AUTH_AUTH0_DOMAIN}
         clientId: ${AUTH_AUTH0_CLIENT_ID}
         clientSecret: ${AUTH_AUTH0_CLIENT_SECRET}
-        # audience: ${AUTH_AUTH0_AUDIENCE}
+        audience: ${AUTH_AUTH0_AUDIENCE}
         # these are optional, and we are using the defaults
         # if added, we need to update ./charts/backstage/Values.yaml
         # connection: ${AUTH_AUTH0_CONNECTION}

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -79,7 +79,7 @@ auth:
         domain: localhost:4400
         clientId: backstage_auth0_client_id
         clientSecret: backstage_auth0_client_secret
-        # audience: https://frontside-backstage
+        audience: https://frontside-backstage
     github:
       development:
         clientId: ${AUTH_GITHUB_CLIENT_ID}


### PR DESCRIPTION
## Motivation

This seems to be the cause of the Unauthorized errors in production. It must be doing extra work in production that isn't run locally, but we do want it enabled to explore RBAC. Turn it on and we will play with settings.
