### PR TITLE
inject variables into frontend during build

### DIFF
--- a/.github/workflows/deploy-preview-tag.yaml
+++ b/.github/workflows/deploy-preview-tag.yaml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - name: Set PR Number
         run: echo "PR_NUMBER=`echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }'`" >> $GITHUB_ENV
-
+      - run: yarn
       - name: Create Environment
         run: ./.scripts/humanitec.mjs clone-environment $PR_NUMBER

--- a/.github/workflows/deploy-preview-tag.yaml
+++ b/.github/workflows/deploy-preview-tag.yaml
@@ -18,26 +18,4 @@ jobs:
         run: echo "PR_NUMBER=`echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }'`" >> $GITHUB_ENV
 
       - name: Create Environment
-        run: |-
-          curl \
-            --request POST 'https://api.humanitec.io/orgs/${{ secrets.HUMANITEC_ORG_ID }}/apps/backstage/envs' \
-            --header 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
-            --header 'Content-Type: application/json' \
-            --data-raw '{
-                "from_deploy_id": "'development'",
-                "id": "'pr$PR_NUMBER'",
-                "name": "'pr$PR_NUMBER'",
-                "type": "'preview'",
-            }'
-      - name: Add Automation Rule
-        run: |-
-          curl \
-            --request POST 'https://api.humanitec.io/orgs/${{ secrets.HUMANITEC_ORG_ID }}/apps/backstage/envs/pr${{ env.PR_NUMBER }}/rules' \
-            --header 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
-            --header 'Content-Type: application/json' \
-            --data-raw '{
-                "active": "'true'",
-                "artefacts_filter": "'$ARTEFACTS_FILTER'",
-                "match_ref": "'refs/heads/$PR_NUMBER/merge'",
-                "type": "'update'",
-            }'
+        run: ./.scripts/humanitec.mjs clone-environment $PR_NUMBER

--- a/.github/workflows/deploy-preview-tag.yaml
+++ b/.github/workflows/deploy-preview-tag.yaml
@@ -1,0 +1,39 @@
+name: Create Deploy Preview Environment
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+env:
+  ARTEFACTS_FILTER: us-central1-docker.pkg.dev/frontside-humanitec/frontside-artifacts/backstage
+
+jobs:
+  create-environment:
+    if: github.event.label.name == 'deploy-preview'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Environment
+        run: |-
+          curl \
+            --request POST 'https://api.humanitec.io/orgs/${{ secrets.HUMANITEC_ORG_ID }}/apps/backstage/envs' \
+            --header 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
+            --header 'Content-Type: application/json' \
+            --data-raw '{
+                "from_deploy_id": "'development'",
+                "id": "'pr$PR_NUMBER'",
+                "name": "'pr$PR_NUMBER'",
+                "type": "'preview'",
+            }'
+      - name: Add Automation Rule
+        run: |-
+          curl \
+            --request POST 'https://api.humanitec.io/orgs/${{ secrets.HUMANITEC_ORG_ID }}/apps/backstage/envs/pr${{ env.PR_NUMBER }}/rules' \
+            --header 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
+            --header 'Content-Type: application/json' \
+            --data-raw '{
+                "active": "'true'",
+                "artefacts_filter": "'$ARTEFACTS_FILTER'",
+                "match_ref": "'refs/heads/$PR_NUMBER/merge'",
+                "type": "'update'",
+            }'

--- a/.github/workflows/deploy-preview-tag.yaml
+++ b/.github/workflows/deploy-preview-tag.yaml
@@ -10,9 +10,13 @@ env:
 
 jobs:
   create-environment:
+    name: Create And Setup Automation
     if: github.event.label.name == 'deploy-preview'
     runs-on: ubuntu-latest
     steps:
+      - name: Set PR Number
+        run: echo "PR_NUMBER=`echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }'`" >> $GITHUB_ENV
+
       - name: Create Environment
         run: |-
           curl \

--- a/.github/workflows/deploy-preview-tidy.yaml
+++ b/.github/workflows/deploy-preview-tidy.yaml
@@ -1,0 +1,15 @@
+name: Tidy Deploy Preview Environment
+
+on:
+  schedule:
+    # Runs "daily at 7:45 PM ET" (see https://crontab.guru)
+    - cron: '45 0 * * *'
+
+jobs:
+  clean-environments:
+    name: Clean Deployments
+    runs-on: ubuntu-latest
+    steps:
+      - run: yarn
+      - name: Create Environment
+        run: ./.scripts/humanitec.mjs tidy-previews

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,7 +54,8 @@ jobs:
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
-          APP_CONFIG_auth_providers_auth0_production_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
+          APP_CONFIG_auth_providers_auth0_development_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
+          APP_CONFIG_auth_providers_auth0_development_clientId: ${{ secrets.AUTH_AUTH0_CLIENT_ID }}
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,7 +33,7 @@ jobs:
           install_components: gke-gcloud-auth-plugin
 
       - name: Set Tag with SHA
-        run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-6`" >> $GITHUB_ENV
+        run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-7`" >> $GITHUB_ENV
 
       - run: yarn
       - run: yarn tsc

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,7 +48,7 @@ jobs:
         # it is different from the others, run it separate with
         # the envs that it needs for injection in the frontend
         # for config which happens only at build time injection
-        run: yarn build-frontend
+        run: yarn workspace app build
         env:
           APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,9 +50,9 @@ jobs:
         # for config which happens only at build time injection
         run: yarn workspace app build
         env:
-          APP_CONFIG_app_baseUrl: https://pr$PR_NUMBER--backstage.frontside.services
-          APP_CONFIG_backend_baseUrl: https://pr$PR_NUMBER--backstage.frontside.services
-          APP_CONFIG_backend_cors_origin: https://pr$PR_NUMBER--backstage.frontside.services
+          APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
+          APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
+          APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,6 +34,11 @@ jobs:
 
       - name: Install/Build Backstage
         run: yarn && yarn tsc && yarn build
+        # the frontend app needs envs for config for build time injection
+        env:
+          APP_CONFIG_app_baseUrl: https://backstage.frontside.services
+          APP_CONFIG_backend_baseUrl: https://backstage.frontside.services
+          APP_CONFIG_backend_cors_origin: https://backstage.frontside.services
 
       - name: Set Tag with SHA
         run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-6`" >> $GITHUB_ENV

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,6 +50,7 @@ jobs:
         # for config which happens only at build time injection
         run: yarn workspace app build
         env:
+          NODE_ENV: production
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
@@ -57,6 +58,8 @@ jobs:
 
       - name: Build Backstage Backend
         run: yarn build
+        env:
+          NODE_ENV: production
 
       - name: Cloud Build & Push to Artifacts Registry
         run: gcloud builds submit . --config=cloudbuild.yaml --substitutions=_IMAGE="$IMAGE:$TAG"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,6 +53,7 @@ jobs:
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
+          AUTH_AUTH0_DOMAIN: frontside.us.auth0.com
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,9 +50,9 @@ jobs:
         # for config which happens only at build time injection
         run: yarn workspace app build
         env:
-          APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
-          APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
-          APP_CONFIG_backend_cors_origin: https://${PR_NUMBER}--backstage.frontside.services
+          APP_CONFIG_app_baseUrl: https://pr$PR_NUMBER--backstage.frontside.services
+          APP_CONFIG_backend_baseUrl: https://pr$PR_NUMBER--backstage.frontside.services
+          APP_CONFIG_backend_cors_origin: https://pr$PR_NUMBER--backstage.frontside.services
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,7 +48,7 @@ jobs:
         # it is different from the others, run it separate with
         # the envs that it needs for injection in the frontend
         # for config which happens only at build time injection
-        run: yarn workspace app build
+        run: yarn build-frontend
         env:
           APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,7 +53,7 @@ jobs:
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
-          AUTH_AUTH0_DOMAIN: frontside.us.auth0.com
+          APP_CONFIG_auth_providers_auth0_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,16 +32,25 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
 
-      - name: Install/Build Backstage
-        run: yarn && yarn tsc && yarn build
-        # the frontend app needs envs for config for build time injection
-        env:
-          APP_CONFIG_app_baseUrl: https://backstage.frontside.services
-          APP_CONFIG_backend_baseUrl: https://backstage.frontside.services
-          APP_CONFIG_backend_cors_origin: https://backstage.frontside.services
-
       - name: Set Tag with SHA
         run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-6`" >> $GITHUB_ENV
+
+      - run: yarn
+      - run: yarn tsc
+
+      - name: Build Backstage Frontend
+        # this is skipped by the main `yarn build` command as
+        # it is different from the others, run it separate with
+        # the envs that it needs for injection in the frontend
+        # for config which happens only at build time injection
+        run: yarn workspace app build
+        env:
+          APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
+          APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
+          APP_CONFIG_backend_cors_origin: https://${PR_NUMBER}--backstage.frontside.services
+
+      - name: Build Backstage Backend
+        run: yarn build
 
       - name: Cloud Build & Push to Artifacts Registry
         run: gcloud builds submit . --config=cloudbuild.yaml --substitutions=_IMAGE="$IMAGE:$TAG"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,6 +37,11 @@ jobs:
 
       - run: yarn
       - run: yarn tsc
+      - name: create empty credentials config file
+        run: |
+          echo "creating empty creds file to avoid build time injection error"
+          mkdir credentials
+          touch credentials/backstage-app-credentials.yaml
 
       - name: Build Backstage Frontend
         # this is skipped by the main `yarn build` command as

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,7 +53,7 @@ jobs:
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
-          APP_CONFIG_auth_providers_auth0_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
+          APP_CONFIG_auth_providers_auth0_production_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -76,7 +76,7 @@ jobs:
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
-          AUTH_AUTH0_DOMAIN: frontside.us.auth0.com
+          APP_CONFIG_auth_providers_auth0_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -73,9 +73,9 @@ jobs:
         # for config which happens only at build time injection
         run: yarn workspace app build
         env:
-          APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
-          APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
-          APP_CONFIG_backend_cors_origin: https://${PR_NUMBER}--backstage.frontside.services
+          APP_CONFIG_app_baseUrl: https://pr$PR_NUMBER--backstage.frontside.services
+          APP_CONFIG_backend_baseUrl: https://pr$PR_NUMBER--backstage.frontside.services
+          APP_CONFIG_backend_cors_origin: https://pr$PR_NUMBER--backstage.frontside.services
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -76,6 +76,7 @@ jobs:
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
+          AUTH_AUTH0_DOMAIN: frontside.us.auth0.com
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -71,7 +71,7 @@ jobs:
         # it is different from the others, run it separate with
         # the envs that it needs for injection in the frontend
         # for config which happens only at build time injection
-        run: yarn workspace app build
+        run: yarn build-frontend
         env:
           APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -24,7 +24,7 @@ jobs:
   deploy:
     name: Cloud Build & Deploy
     runs-on: ubuntu-latest
-    if: true # use a tag
+    if: contains( github.event.pull_request.labels.*.name, 'deploy-preview')
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -77,7 +77,8 @@ jobs:
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
-          APP_CONFIG_auth_providers_auth0_production_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
+          APP_CONFIG_auth_providers_auth0_development_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
+          APP_CONFIG_auth_providers_auth0_development_clientId: ${{ secrets.AUTH_AUTH0_CLIENT_ID }}
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -53,6 +53,11 @@ jobs:
       - name: Set Tag With SHA
         run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-6`" >> $GITHUB_ENV
 
+      - name: Check Tag And PR Number Output
+        run: |
+          echo $PR_NUMBER
+          echo $TAG
+
       - name: Install/Build Backstage
         run: yarn && yarn tsc && yarn build
         # the frontend app needs envs for config for build time injection
@@ -60,11 +65,6 @@ jobs:
           APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://${PR_NUMBER}--backstage.frontside.services
-
-      - name: Check Tag And PR Number Output
-        run: |
-          echo $PR_NUMBER
-          echo $TAG
 
       - name: Cloud Build & Push to Artifacts Registry
         run: gcloud builds submit . --config=cloudbuild.yaml --substitutions=_IMAGE="$IMAGE:pr$PR_NUMBER-$TAG"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -7,16 +7,74 @@ jobs:
     name: Publish Previews
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - uses: volta-cli/action@v3
-    - uses: actions/setup-node@v2
-      with:
-        registry-url: https://registry.npmjs.org
-    - uses: thefrontside/actions/publish-pr-preview@v2
-      with:
-        INSTALL_SCRIPT: yarn install --frozen-lockfile && yarn tsc && yarn build
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: volta-cli/action@v3
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: https://registry.npmjs.org
+      - uses: thefrontside/actions/publish-pr-preview@v2
+        with:
+          INSTALL_SCRIPT: yarn install --frozen-lockfile && yarn tsc && yarn build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+
+  deploy:
+    name: Cloud Build & Deploy
+    runs-on: ubuntu-latest
+    if: false # use a tag
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    concurrency: ${{ github.ref }}
+    env:
+      IMAGE: 'us-central1-docker.pkg.dev/frontside-humanitec/frontside-artifacts/backstage'
+      USE_GKE_GCLOUD_AUTH_PLUGIN: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v3
+
+      - name: Google Cloud Workload Identity Federation
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.CLOUD_WORKLOAD_PROVIDER }}
+          service_account: ${{ secrets.CLOUD_SERVICE_ACCOUNT }}
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          install_components: gke-gcloud-auth-plugin
+
+      - name: Install/Build Backstage
+        run: yarn && yarn tsc && yarn build
+
+      - name: Set PR Number
+        run: echo "PR_NUMBER=`echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }'`" >> $GITHUB_ENV
+
+      - name: Set Tag With SHA
+        run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-6`" >> $GITHUB_ENV
+
+      - name: Check Tag And PR Number Output
+        run: |
+          echo $PR_NUMBER
+          echo $TAG
+
+      - name: Cloud Build & Push to Artifacts Registry
+        if: false
+        run: gcloud builds submit . --config=cloudbuild.yaml --substitutions=_IMAGE="$IMAGE:pr$PR_NUMBER-$TAG"
+
+      - name: Inform Humanitec
+        if: false
+        run: |-
+          curl \
+            --request POST 'https://api.humanitec.io/orgs/${{ secrets.HUMANITEC_ORG_ID }}/images/backstage/builds' \
+            --header 'Authorization: Bearer ${{ secrets.HUMANITEC_TOKEN }}' \
+            --header 'Content-Type: application/json' \
+            --data-raw '{
+                "branch": "'$GITHUB_REF_NAME'",
+                "commit": "'$GITHUB_SHA'",
+                "image": "'$IMAGE:pr$PR_NUMBER-$TAG'",
+                "tags": ["'$TAG'"]
+            }'

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -71,7 +71,7 @@ jobs:
         # it is different from the others, run it separate with
         # the envs that it needs for injection in the frontend
         # for config which happens only at build time injection
-        run: yarn build-frontend
+        run: yarn workspace app build
         env:
           APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -62,7 +62,6 @@ jobs:
           echo $TAG
 
       - name: Cloud Build & Push to Artifacts Registry
-        if: false
         run: gcloud builds submit . --config=cloudbuild.yaml --substitutions=_IMAGE="$IMAGE:pr$PR_NUMBER-$TAG"
 
       - name: Inform Humanitec

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -73,9 +73,9 @@ jobs:
         # for config which happens only at build time injection
         run: yarn workspace app build
         env:
-          APP_CONFIG_app_baseUrl: https://pr$PR_NUMBER--backstage.frontside.services
-          APP_CONFIG_backend_baseUrl: https://pr$PR_NUMBER--backstage.frontside.services
-          APP_CONFIG_backend_cors_origin: https://pr$PR_NUMBER--backstage.frontside.services
+          APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
+          APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
+          APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -51,7 +51,7 @@ jobs:
         run: echo "PR_NUMBER=`echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }'`" >> $GITHUB_ENV
 
       - name: Set Tag With SHA
-        run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-6`" >> $GITHUB_ENV
+        run: echo "TAG=`echo ${{ github.event.pull_request.head.sha }} | cut -c 1-7`" >> $GITHUB_ENV
 
       - name: Check Tag And PR Number Output
         run: |

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -76,7 +76,7 @@ jobs:
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
-          APP_CONFIG_auth_providers_auth0_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
+          APP_CONFIG_auth_providers_auth0_production_domain: ${{ secrets.AUTH_AUTH0_DOMAIN }}
 
       - name: Build Backstage Backend
         run: yarn build

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -65,7 +65,6 @@ jobs:
         run: gcloud builds submit . --config=cloudbuild.yaml --substitutions=_IMAGE="$IMAGE:pr$PR_NUMBER-$TAG"
 
       - name: Inform Humanitec
-        if: false
         run: |-
           curl \
             --request POST 'https://api.humanitec.io/orgs/${{ secrets.HUMANITEC_ORG_ID }}/images/backstage/builds' \

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -24,7 +24,7 @@ jobs:
   deploy:
     name: Cloud Build & Deploy
     runs-on: ubuntu-latest
-    if: false # use a tag
+    if: true # use a tag
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -73,6 +73,7 @@ jobs:
         # for config which happens only at build time injection
         run: yarn workspace app build
         env:
+          NODE_ENV: production
           APP_CONFIG_app_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://pr${{ env.PR_NUMBER }}--backstage.frontside.services
@@ -80,6 +81,8 @@ jobs:
 
       - name: Build Backstage Backend
         run: yarn build
+        env:
+          NODE_ENV: production
 
       - name: Cloud Build & Push to Artifacts Registry
         run: gcloud builds submit . --config=cloudbuild.yaml --substitutions=_IMAGE="$IMAGE:pr$PR_NUMBER-$TAG"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -58,13 +58,22 @@ jobs:
           echo $PR_NUMBER
           echo $TAG
 
-      - name: Install/Build Backstage
-        run: yarn && yarn tsc && yarn build
-        # the frontend app needs envs for config for build time injection
+      - run: yarn
+      - run: yarn tsc
+
+      - name: Build Backstage Frontend
+        # this is skipped by the main `yarn build` command as
+        # it is different from the others, run it separate with
+        # the envs that it needs for injection in the frontend
+        # for config which happens only at build time injection
+        run: yarn workspace app build
         env:
           APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
           APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
           APP_CONFIG_backend_cors_origin: https://${PR_NUMBER}--backstage.frontside.services
+
+      - name: Build Backstage Backend
+        run: yarn build
 
       - name: Cloud Build & Push to Artifacts Registry
         run: gcloud builds submit . --config=cloudbuild.yaml --substitutions=_IMAGE="$IMAGE:pr$PR_NUMBER-$TAG"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -47,14 +47,19 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
 
-      - name: Install/Build Backstage
-        run: yarn && yarn tsc && yarn build
-
       - name: Set PR Number
         run: echo "PR_NUMBER=`echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }'`" >> $GITHUB_ENV
 
       - name: Set Tag With SHA
         run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-6`" >> $GITHUB_ENV
+
+      - name: Install/Build Backstage
+        run: yarn && yarn tsc && yarn build
+        # the frontend app needs envs for config for build time injection
+        env:
+          APP_CONFIG_app_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
+          APP_CONFIG_backend_baseUrl: https://${PR_NUMBER}--backstage.frontside.services
+          APP_CONFIG_backend_cors_origin: https://${PR_NUMBER}--backstage.frontside.services
 
       - name: Check Tag And PR Number Output
         run: |

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -60,6 +60,11 @@ jobs:
 
       - run: yarn
       - run: yarn tsc
+      - name: create empty credentials config file
+        run: |
+          echo "creating empty creds file to avoid build time injection error"
+          mkdir credentials
+          touch credentials/backstage-app-credentials.yaml
 
       - name: Build Backstage Frontend
         # this is skipped by the main `yarn build` command as

--- a/.scripts/humanitec.mjs
+++ b/.scripts/humanitec.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { main, createTask, fetch } from 'effection';
+import crypto from 'node:crypto';
+
+main(function* () {
+  let task = createTask(function* (scope) {
+    const program = new Command();
+    program
+      .command('get-environments')
+      .action(async () => await scope.run(getEnvironments()));
+    program
+      .command('clone-environment')
+      .argument('[newEnvName]', 'name of new environment')
+      .action(
+        async newEnvName => await scope.run(cloneEnvironment({ newEnvName })),
+      );
+
+    yield program.parseAsync();
+  });
+  task.start();
+  task.catchHalt().catch(err => {
+    console.error(err);
+  });
+});
+
+function* getEnvironments() {
+  const { HUMANITEC_ORG_ID } = process.env;
+  if (!process.env.HUMANITEC_ORG_ID)
+    throw new Error('HUMANITEC_ORG_ID env need to be set');
+
+  let url = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs`;
+  let result = yield fetch(url, {
+    method: 'GET',
+    ...createHeaders(),
+  });
+
+  yield processResponse({ result });
+}
+
+function* cloneEnvironment({ newEnvName }) {
+  if (!newEnvName) newEnvName = crypto.randomUUID();
+
+  let quotes = '===================';
+  const { HUMANITEC_ORG_ID } = process.env;
+  if (!process.env.HUMANITEC_ORG_ID)
+    throw new Error('HUMANITEC_ORG_ID env need to be set');
+
+  let devEnvUrl = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs/development`;
+  let devEnvResult = yield fetch(devEnvUrl, {
+    method: 'GET',
+    ...createHeaders(),
+  });
+  let devEnv = yield processResponse({
+    result: devEnvResult,
+    label: `development env metadata\n${quotes}`,
+  });
+
+  let url = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs`;
+  let result = yield fetch(url, {
+    method: 'POST',
+    ...createHeaders(),
+    body: JSON.stringify({
+      from_deploy_id: devEnv.from_deploy_id,
+      id: newEnvName,
+      name: newEnvName,
+      type: 'preview',
+    }),
+  });
+  if (result.statusText === 'Conflict') {
+    console.log(`Environment ${newEnvName} already exists. Skipping clone.`);
+    return;
+  }
+
+  yield processResponse({
+    result,
+    label: `newly created ${newEnvName} env metadata\n${quotes}`,
+  });
+
+  let ruleUrl = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs/${newEnvName}/rules`;
+  let artefactsFilter = `us-central1-docker.pkg.dev/frontside-humanitec/frontside-artifacts/backstage`;
+  let ruleResult = yield fetch(ruleUrl, {
+    method: 'POST',
+    ...createHeaders(),
+    body: JSON.stringify({
+      active: true,
+      artefacts_filter: [artefactsFilter],
+      match_ref: `refs/heads/${newEnvName}/merge`,
+      type: 'update',
+    }),
+  });
+
+  yield processResponse({
+    result: ruleResult,
+  });
+}
+
+function createHeaders({ extraHeaders = {} } = { extraHeaders: {} }) {
+  if (!process.env.HUMANITEC_TOKEN)
+    throw new Error('HUMANITEC_TOKEN env need to be set');
+
+  return {
+    headers: {
+      Authorization: `Bearer ${process.env.HUMANITEC_TOKEN}`,
+      'Content-Type': 'application/json',
+      ...extraHeaders,
+    },
+  };
+}
+
+function* processResponse({ result, label }) {
+  let response = yield result.json();
+  if (result.status < 400) {
+    if (label) console.log(label);
+    console.dir(response);
+    return response;
+  } else {
+    console.error(result);
+    console.error(response);
+    throw new Error(response.message);
+  }
+}

--- a/.scripts/humanitec.mjs
+++ b/.scripts/humanitec.mjs
@@ -46,14 +46,14 @@ function* cloneEnvironment({ newEnvName }) {
   if (!process.env.HUMANITEC_ORG_ID)
     throw new Error('HUMANITEC_ORG_ID env need to be set');
 
-  let devEnvUrl = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs/development`;
+  let devEnvUrl = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs/production`;
   let devEnvResult = yield fetch(devEnvUrl, {
     method: 'GET',
     ...createHeaders(),
   });
   let devEnv = yield processResponse({
     result: devEnvResult,
-    label: `development env metadata\n${quotes}`,
+    label: `production env metadata\n${quotes}`,
   });
 
   let url = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs`;

--- a/.scripts/humanitec.mjs
+++ b/.scripts/humanitec.mjs
@@ -1,20 +1,32 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { main, createTask, fetch } from 'effection';
 import crypto from 'node:crypto';
+import { main, createTask, fetch } from 'effection';
+import { Octokit } from 'octokit';
 
 main(function* () {
+  if (!process.env.HUMANITEC_ORG_ID)
+    throw new Error('HUMANITEC_ORG_ID env need to be set');
+
   let task = createTask(function* (scope) {
     const program = new Command();
     program
       .command('get-environments')
+      .alias('get-envs')
       .action(async () => await scope.run(getEnvironments()));
     program
       .command('clone-environment')
+      .alias('clone-env')
       .argument('[newEnvName]', 'name of new environment')
       .action(
         async newEnvName => await scope.run(cloneEnvironment({ newEnvName })),
       );
+    program
+      .command('tidy-previews')
+      .action(async () => await scope.run(tidyPreviews()));
+    program
+      .command('replicas')
+      .action(async () => await scope.run(getReplicas()));
 
     yield program.parseAsync();
   });
@@ -24,10 +36,8 @@ main(function* () {
   });
 });
 
-function* getEnvironments() {
+function* getEnvironments({ silent = false }) {
   const { HUMANITEC_ORG_ID } = process.env;
-  if (!process.env.HUMANITEC_ORG_ID)
-    throw new Error('HUMANITEC_ORG_ID env need to be set');
 
   let url = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs`;
   let result = yield fetch(url, {
@@ -35,7 +45,7 @@ function* getEnvironments() {
     ...createHeaders(),
   });
 
-  yield processResponse({ result });
+  return yield processResponse({ result, silent });
 }
 
 function* cloneEnvironment({ newEnvName }) {
@@ -95,6 +105,112 @@ function* cloneEnvironment({ newEnvName }) {
   });
 }
 
+function* tidyPreviews() {
+  let envs = yield getEnvironments({ silent: true });
+  let previews = envs.filter(env => env.type === 'preview');
+
+  let deletedEnvs = yield deleteUnusedEnvironments({ previews });
+  let deletedEnvsID = deletedEnvs.map(env => env.id);
+  let remainingEnvs = previews.filter(env => !deletedEnvsID.includes(env.id));
+  let spunDownEnvs = yield spinDownEnvironment({ previews: remainingEnvs });
+}
+
+function* deleteUnusedEnvironments({ previews }) {
+  let listOfPRs = yield queryRepoPRs();
+  let listOfPRNumbers = listOfPRs.map(pull => `pr${pull.number}`);
+  let previewsToDelete = previews.filter(
+    preview => !listOfPRNumbers.includes(preview.id),
+  );
+
+  const { HUMANITEC_ORG_ID } = process.env;
+  for (let preview of previewsToDelete) {
+    let url = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs/${preview.id}`;
+    let result = yield fetch(url, {
+      method: 'DELETE',
+      ...createHeaders(),
+    });
+
+    if (result.status === 204) {
+      console.log(`deleting ${preview.id}`);
+    } else {
+      console.log(
+        `attempted to delete ${preview.id}, but an issue arose, skipping`,
+      );
+      console.error(result);
+    }
+  }
+
+  return previewsToDelete;
+}
+
+function* queryRepoPRs() {
+  if (!process.env.GITHUB_TOKEN)
+    throw new Error('GITHUB_TOKEN is required to query for PRs');
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+  const { data } = yield octokit.rest.pulls.list({
+    owner: 'thefrontside',
+    repo: 'playhouse',
+    state: 'open',
+  });
+
+  return data;
+}
+
+function* spinDownEnvironment({ previews }) {
+  const { HUMANITEC_ORG_ID } = process.env;
+  let envsToSpinDown = [];
+
+  for (let preview of previews) {
+    if (preview.last_deploy) {
+      let lastDeployDT = new Date(preview.last_deploy.created_at);
+
+      let minutesSinceLastDeploy = (new Date() - lastDeployDT) / 1000 / 60;
+      let minutesInDay = 24 * 60 - 9999;
+      if (minutesSinceLastDeploy > minutesInDay) envsToSpinDown.push(preview);
+    }
+  }
+
+  for (let preview of envsToSpinDown) {
+    let url = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs/${preview.id}/runtime/replicas`;
+    // let url = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs/${preview.id}/runtime`;
+    // method: 'GET',
+    let result = yield fetch(url, {
+      method: 'PATCH',
+      ...createHeaders(),
+      body: JSON.stringify({
+        backstage: 0,
+      }),
+    });
+
+    if (result.status === 204) {
+      console.log(`spinning down ${preview.id}`);
+    } else {
+      console.log(
+        `attempted to spin down ${preview.id}, but an issue arose, skipping`,
+      );
+      console.error(result);
+    }
+  }
+
+  return envsToSpinDown;
+}
+
+function* getReplicas() {
+  let envs = yield getEnvironments({ silent: true });
+  const { HUMANITEC_ORG_ID } = process.env;
+
+  for (let env of envs) {
+    let url = `https://api.humanitec.io/orgs/${HUMANITEC_ORG_ID}/apps/backstage/envs/${env.id}/runtime`;
+    let result = yield fetch(url, {
+      method: 'GET',
+      ...createHeaders(),
+    });
+
+    yield processResponse({ result });
+  }
+}
+
 function createHeaders({ extraHeaders = {} } = { extraHeaders: {} }) {
   if (!process.env.HUMANITEC_TOKEN)
     throw new Error('HUMANITEC_TOKEN env need to be set');
@@ -108,15 +224,14 @@ function createHeaders({ extraHeaders = {} } = { extraHeaders: {} }) {
   };
 }
 
-function* processResponse({ result, label }) {
+function* processResponse({ result, label, silent, throwOnError = true }) {
   let response = yield result.json();
   if (result.status < 400) {
-    if (label) console.log(label);
-    console.dir(response);
+    if (label && !silent) console.log(label);
+    if (!silent) console.dir(response, { depth: 6 });
     return response;
   } else {
-    console.error(result);
     console.error(response);
-    throw new Error(response.message);
+    if (throwOnError) throw new Error(response.message);
   }
 }

--- a/.scripts/inject-config.mjs
+++ b/.scripts/inject-config.mjs
@@ -11,7 +11,7 @@ async function inject() {
   await injectConfig({
     staticDir: './dist/static',
     logger: console,
-    appConfigs: config,
+    appConfigs: config.frontendAppConfigs,
   });
 }
 

--- a/.scripts/inject-config.mjs
+++ b/.scripts/inject-config.mjs
@@ -1,0 +1,118 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { findPaths } from '@backstage/cli-common';
+import { Command } from 'commander';
+import { loadConfig, loadConfigSchema } from '@backstage/config-loader';
+import { getPackages } from '@manypkg/get-packages';
+import { ConfigReader } from '@backstage/config';
+
+async function inject() {
+  const config = await readConfig(process.argv);
+  await injectConfig({
+    staticDir: './packages/app/dist/static',
+    logger: console,
+    appConfigs: config,
+  });
+}
+
+async function readConfig(argv) {
+  const program = new Command();
+  program.option(
+    '--config <path...>',
+    'Config files to load instead of app-config.yaml',
+    [],
+  );
+
+  program.parse(argv);
+
+  const opts = program.opts();
+
+  const paths = findPaths(import.meta.url);
+
+  const { packages } = await getPackages(paths.targetDir);
+
+  const schema = await loadConfigSchema({
+    dependencies: packages.map(p => p.packageJson.name),
+    // Include the package.json in the project root if it exists
+    packagePaths: [paths.resolveTargetRoot('package.json')],
+  });
+
+  const configTargets = opts.config.map(arg => ({
+    path: paths.resolveTarget(arg),
+  }));
+
+  const { appConfigs } = await loadConfig({
+    configRoot: paths.targetRoot,
+    configTargets: configTargets,
+  });
+
+  const frontendAppConfigs = schema.process(appConfigs, {
+    visibility: ['frontend'],
+    withFilteredKeys: true,
+    withDeprecatedKeys: true,
+  });
+
+  const frontendConfig = ConfigReader.fromConfigs(frontendAppConfigs);
+
+  const url = resolveBaseUrl(frontendConfig);
+
+  const host =
+    frontendConfig.getOptionalString('app.listen.host') || url.hostname;
+  const port =
+    frontendConfig.getOptionalNumber('app.listen.port') ||
+    Number(url.port) ||
+    (url.protocol === 'https:' ? 443 : 80);
+
+  return {
+    host,
+    port,
+    base: url.pathname,
+    frontendConfig,
+    frontendAppConfigs,
+  };
+}
+
+function resolveBaseUrl(config) {
+  const baseUrl = config.getString('app.baseUrl');
+  try {
+    return new URL(baseUrl);
+  } catch (error) {
+    throw new Error(`Invalid app.baseUrl, ${error}`);
+  }
+}
+
+async function injectConfig({ staticDir, logger, appConfigs }) {
+  const files = await fs.readdir(staticDir);
+  const jsFiles = files.filter(file => file.endsWith('.js'));
+
+  const escapedData = JSON.stringify(appConfigs).replace(/("|'|\\)/g, '\\$1');
+  const injected = `/*__APP_INJECTED_CONFIG_MARKER__*/"${escapedData}"/*__INJECTED_END__*/`;
+
+  for (const jsFile of jsFiles) {
+    const filePath = path.join(staticDir, jsFile);
+
+    const content = await fs.readFile(filePath, 'utf8');
+    if (content.includes('__APP_INJECTED_RUNTIME_CONFIG__')) {
+      logger.info(`Injecting env config into ${jsFile}`);
+
+      const newContent = content.replace(
+        '"__APP_INJECTED_RUNTIME_CONFIG__"',
+        injected,
+      );
+      await fs.writeFile(filePath, newContent, 'utf8');
+      return;
+    } else if (content.includes('__APP_INJECTED_CONFIG_MARKER__')) {
+      logger.info(`Replacing injected env config in ${jsFile}`);
+
+      const newContent = content.replace(
+        /\/\*__APP_INJECTED_CONFIG_MARKER__\*\/.*\/\*__INJECTED_END__\*\//,
+        injected,
+      );
+      await fs.writeFile(filePath, newContent, 'utf8');
+      return;
+    }
+  }
+  logger.info('Env config not injected');
+}
+
+inject();

--- a/.scripts/inject-config.mjs
+++ b/.scripts/inject-config.mjs
@@ -9,7 +9,7 @@ import { ConfigReader } from '@backstage/config';
 async function inject() {
   const config = await readConfig(process.argv);
   await injectConfig({
-    staticDir: './packages/app/dist/static',
+    staticDir: './dist/static',
     logger: console,
     appConfigs: config,
   });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start-backend": "yarn workspace backend start",
     "start-sim": "yarn workspace simulation watch",
     "build": "yarn tsc && backstage-cli repo build --all",
+    "build-frontend": "cd packages/app && yarn build",
     "build-image": "yarn workspace backend build-image",
     "pretsc": "lerna run generate",
     "tsc": "tsc",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "start-backend": "yarn workspace backend start",
     "start-sim": "yarn workspace simulation watch",
     "build": "yarn tsc && backstage-cli repo build --all",
-    "build-frontend": "cd packages/app && yarn build",
     "build-image": "yarn workspace backend build-image",
     "pretsc": "lerna run generate",
     "tsc": "tsc",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -57,7 +57,9 @@
   },
   "scripts": {
     "start": "backstage-cli package start",
-    "build": "backstage-cli package build",
+    "build": "yarn backstage-build && yarn inject-config",
+    "backstage-build": "backstage-cli package build",
+    "inject-config": "node ../../.scripts/inject-config.mjs --config ../../app-config.yaml --config ../../app-config.production.yaml",
     "clean": "backstage-cli package clean",
     "test": "backstage-cli package test",
     "test:e2e": "cross-env PORT=3001 start-server-and-test start http://localhost:3001 cy:dev",

--- a/packages/backend/src/plugins/app.ts
+++ b/packages/backend/src/plugins/app.ts
@@ -10,5 +10,6 @@ export default async function createPlugin({
     logger,
     config,
     appPackageName: 'app',
+    disableConfigInjection: true,
   });
 }


### PR DESCRIPTION
## Motivation

We want to be able to inject the variables into a frontend at build time up front instead of during the backend startup process. If we expect the container to be readonly, then we cannot write a config file through the backend.

If the variables aren't injected at build time, then it breaks in subtle ways. We can emulate the readonly container by turning off injection via `disableConfigInjection`. Here we can see the auth break as we set the app url.

![image](https://user-images.githubusercontent.com/2019387/215661652-b0ad7880-36fa-47bf-a64e-d6b1e3fd2b77.png)

It seems that the envs that we need for the fronted are only these three, but a bit unclear here and plenty of places / ways to pull them in. We set `app.baseUrl`, `backend.baseUrl`, and `backend.cors.origin` so going to start with these as an input. It also appears we currently don't use the proxy. **EDIT** We also needed auth variables.
![image](https://user-images.githubusercontent.com/2019387/215794283-5d775081-0f9b-44bb-8350-e8535cc807b5.png)

## Approach

Pull out some `app-backend` code to write a script which injects the vars during build.
