### PR TITLE
Make @frontside/backstage-plugins-scaffolder-workflow public

### DIFF
--- a/plugins/scaffolder-frontend-workflow/package.json
+++ b/plugins/scaffolder-frontend-workflow/package.json
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
## Motivation

#216 didn't publish because @frontside/backstage-plugins-scaffolder-workflow because it's private

## Approach

Make @frontside/backstage-plugins-scaffolder-workflow public