### PR TITLE
pipe built-in GH token to tidy-previews

### DIFF
--- a/.github/workflows/deploy-preview-tidy.yaml
+++ b/.github/workflows/deploy-preview-tidy.yaml
@@ -16,5 +16,7 @@ jobs:
       - name: Create Environment
         run: node ./.scripts/humanitec.mjs tidy-previews
         env:
+          # using built-in token for restricted access to only this repo
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUMANITEC_ORG_ID: ${{ secrets.HUMANITEC_ORG_ID }}
           HUMANITEC_TOKEN: ${{ secrets.HUMANITEC_TOKEN }}


### PR DESCRIPTION
## Motivation

The cron to tidy up the preview environments was failing as it didn't pick up the github token available in the runner.

## Approach

Explicitly pipe the token to the command env.
