### PR TITLE
bump action/checkout to v3 to avoid node 12 deprecation

### DIFF
--- a/.github/workflows/deploy-preview-tag.yaml
+++ b/.github/workflows/deploy-preview-tag.yaml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.label.name == 'deploy-preview'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v3
       - name: Set PR Number
         run: echo "PR_NUMBER=`echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }'`" >> $GITHUB_ENV

--- a/.github/workflows/deploy-preview-tidy.yaml
+++ b/.github/workflows/deploy-preview-tidy.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: volta-cli/action@v3
       - run: yarn
-      - name: Create Environment
+      - name: Tidy Previews
         run: node ./.scripts/humanitec.mjs tidy-previews
         env:
           # using built-in token for restricted access to only this repo

--- a/.github/workflows/deploy-preview-tidy.yaml
+++ b/.github/workflows/deploy-preview-tidy.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Clean Deployments
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v3
       - run: yarn
       - name: Create Environment

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v3
 
       - name: Google Cloud Workload Identity Federation

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -33,7 +33,7 @@ jobs:
       IMAGE: 'us-central1-docker.pkg.dev/frontside-humanitec/frontside-artifacts/backstage'
       USE_GKE_GCLOUD_AUTH_PLUGIN: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v3
 
       - name: Google Cloud Workload Identity Federation

--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo


### PR DESCRIPTION
## Motivation

The `action/checkout@v2` uses node 12 which is being deprecated. Bumping to the new version to avoid accidentally breakage when we reach the end of the deprecation period.
