### PR TITLE
Setup Google Cloud Storage with TechDocs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,9 +45,6 @@ jobs:
           touch credentials/backstage-app-credentials.yaml
           echo '"{}"' > credentials/techdocs-bucket-credentials.json
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Build Backstage Frontend
         # this is skipped by the main `yarn build` command as
         # it is different from the others, run it separate with

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           mkdir credentials
           touch credentials/backstage-app-credentials.yaml
-          touch credentials/techdocs-bucket-credentials.json
+          echo '"{}"' > credentials/techdocs-bucket-credentials.json
 
       - name: Build Backstage Frontend
         # this is skipped by the main `yarn build` command as

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,12 +36,14 @@ jobs:
         run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-7`" >> $GITHUB_ENV
 
       - run: yarn
+
       - run: yarn tsc
-      - name: create empty credentials config file
+
+      - name: creating empty creds file to avoid build time injection error
         run: |
-          echo "creating empty creds file to avoid build time injection error"
           mkdir credentials
           touch credentials/backstage-app-credentials.yaml
+          touch credentials/techdocs-bucket-credentials.json
 
       - name: Build Backstage Frontend
         # this is skipped by the main `yarn build` command as

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,6 +45,9 @@ jobs:
           touch credentials/backstage-app-credentials.yaml
           echo '"{}"' > credentials/techdocs-bucket-credentials.json
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Build Backstage Frontend
         # this is skipped by the main `yarn build` command as
         # it is different from the others, run it separate with

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -65,6 +65,7 @@ jobs:
           echo "creating empty creds file to avoid build time injection error"
           mkdir credentials
           touch credentials/backstage-app-credentials.yaml
+          echo '"{}"' > credentials/techdocs-bucket-credentials.json
 
       - name: Build Backstage Frontend
         # this is skipped by the main `yarn build` command as

--- a/app-config.1password.yaml.tpl
+++ b/app-config.1password.yaml.tpl
@@ -22,7 +22,7 @@ auth:
 
 humanitec:
   orgId: the-frontside-software-inc
-  registryUrl: 'northamerica-northeast1-docker.pkg.dev/frontside-backstage/frontside-artifacts'
+  registryUrl: us-central1-docker.pkg.dev/frontside-humanitec/frontside-artifacts
   token: {{ op://shared/Humanitec Token/credential }}
 
 techdocs:

--- a/app-config.1password.yaml.tpl
+++ b/app-config.1password.yaml.tpl
@@ -24,3 +24,12 @@ humanitec:
   orgId: the-frontside-software-inc
   registryUrl: 'northamerica-northeast1-docker.pkg.dev/frontside-backstage/frontside-artifacts'
   token: {{ op://shared/Humanitec Token/credential }}
+
+techdocs:
+  builder: external
+  publisher:
+    type: googleGcs
+    googleGcs:
+      bucketName: {{ op://shared/frontside-techdocs-reader/bucketName }}
+      projectId: {{ op://shared/frontside-techdocs-reader/projectId }}
+      credentials: '{{ op://shared/frontside-techdocs-reader/credentials }}'

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -47,5 +47,9 @@ catalog:
         - allow: [Template]
 
 techdocs:
-  googleGcs:
-    bucketName: frontside-techdocs
+  publisher:
+    type: googleGcs
+    googleGcs:
+      bucketName: ${TECHDOCS_STORAGE_BUCKET}
+      credentials:
+        $file: /app/credentials/techdocs-bucket-credentials.json

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -54,4 +54,4 @@ techdocs:
       bucketName: ${TECHDOCS_STORAGE_BUCKET}
       projectId: ${TECHDOCS_GCLOUD_PROJECT}
       credentials:
-        $file: /app/credentials/techdocs-bucket-credentials.json
+        $include: credentials/techdocs-bucket-credentials.json

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -51,5 +51,6 @@ techdocs:
     type: googleGcs
     googleGcs:
       bucketName: ${TECHDOCS_STORAGE_BUCKET}
+      projectId: ${TECHDOCS_GCLOUD_PROJECT}
       credentials:
         $file: /app/credentials/techdocs-bucket-credentials.json

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -47,6 +47,7 @@ catalog:
         - allow: [Template]
 
 techdocs:
+  builder: external
   publisher:
     type: googleGcs
     googleGcs:

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -45,3 +45,7 @@ catalog:
       target: https://github.com/thefrontside/playhouse/blob/main/templates/standard-microservice/template.yaml
       rules:
         - allow: [Template]
+
+techdocs:
+  googleGcs:
+    bucketName: frontside-techdocs

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -99,5 +99,5 @@ catalog:
 
 humanitec:
   orgId: the-frontside-software-inc
-  registryUrl: 'northamerica-northeast1-docker.pkg.dev/frontside-backstage/frontside-artifacts'
+  registryUrl: us-central1-docker.pkg.dev/frontside-humanitec/frontside-artifacts
   token: ${HUMANITEC_TOKEN}


### PR DESCRIPTION
## Motivation

I'm getting ready for a demo and I want to show how TechDocs works but it needs to be setup correctly.

## Approach

1. Created [frontside-techdocs](https://console.cloud.google.com/storage/browser/frontside-techdocs;tab=objects?forceOnBucketsSortingFiltering=false&project=frontside-humanitec&prefix=&forceOnObjectsSortingFiltering=false) bucket
2. Created frontside-techdocs-reader@frontside-humanitec.iam.gserviceaccount.com service account with read access to the above bucket
3. Configured app-config to use google storage account
