### PR TITLE
export transformSchema from graphql plugin

### DIFF
--- a/.changeset/popular-donuts-draw.md
+++ b/.changeset/popular-donuts-draw.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql': patch
+---
+
+The docs note that transformSchema is an exported function for use with codegen type safety. It was not previously exported, and has now been corrected.

--- a/plugins/graphql/src/index.ts
+++ b/plugins/graphql/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './app';
+export { transformSchema } from './app/transform';


### PR DESCRIPTION
## Motivation

The docs for the graphql plugin noted that you could import `transformSchema` for codegen, but it wasn't correctly exported from the package. It was only exporting the `createRouter` function. Fixing it.

## Approach

Added it as an explicit export from the `src/index.ts`.
