### PR TITLE
Replace api route ref from scaffolder with relative path

### DIFF
--- a/.changeset/calm-cherries-invent.md
+++ b/.changeset/calm-cherries-invent.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-scaffolder-workflow': patch
+---
+
+Eliminate route ref from embedded scaffolder workflow

--- a/plugins/scaffolder-frontend-workflow/src/components/EmbeddedScaffolderWorkflow/EmbeddedScaffolderWorkflow.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/EmbeddedScaffolderWorkflow/EmbeddedScaffolderWorkflow.tsx
@@ -115,7 +115,7 @@ export function EmbeddedScaffolderWorkflow({
           }
         />
         <Route
-          path="/tasks/:taskId"
+          path="tasks/:taskId"
           element={
             <TaskProgress />
           }

--- a/plugins/scaffolder-frontend-workflow/src/components/EmbeddedScaffolderWorkflow/EmbeddedScaffolderWorkflow.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/EmbeddedScaffolderWorkflow/EmbeddedScaffolderWorkflow.tsx
@@ -17,7 +17,6 @@ import type { ComponentType, ReactNode } from 'react';
 import React, { useCallback } from 'react';
 import { Link, Route, Routes, useNavigate } from 'react-router-dom';
 import { Box, Button } from '@material-ui/core';
-import { nextScaffolderTaskRouteRef } from '@backstage/plugin-scaffolder/alpha';
 import { TaskProgress } from '../TaskProgress/TaskProgress';
 
 export type EmbeddedScaffolderWorkflowProps = Omit<
@@ -116,7 +115,7 @@ export function EmbeddedScaffolderWorkflow({
           }
         />
         <Route
-          path={nextScaffolderTaskRouteRef.path}
+          path="/tasks/:taskId"
           element={
             <TaskProgress />
           }


### PR DESCRIPTION
## Motivation

One of our users reported that embedded scaffolder wasn't rendering the task page. This was happening because we navigate to `tasks/:taskId` but progress page is mounted on route ref. The result is that there isn't actually anything to render on `tasks/:taskid`. 

## Approach

Remove the use of route ref in Embedded Scaffolder router. We don't actually need it.
