### PR TITLE
useSecrets prop to embedded scaffolder

### DIFF
--- a/.changeset/warm-trains-wink.md
+++ b/.changeset/warm-trains-wink.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-scaffolder-workflow': patch
+---
+
+Allow passing in useTemplateSecrets to enable use of context higher up in the component tree.

--- a/plugins/scaffolder-frontend-workflow/src/components/EmbeddedScaffolderWorkflow/EmbeddedScaffolderWorkflow.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/EmbeddedScaffolderWorkflow/EmbeddedScaffolderWorkflow.tsx
@@ -6,6 +6,7 @@ import {
   useCustomLayouts,
   useTemplateSecrets,
   ScaffolderTaskOutput,
+  ScaffolderUseTemplateSecrets,
 } from '@backstage/plugin-scaffolder-react';
 import {
   EmbeddableWorkflow,
@@ -32,6 +33,7 @@ export type EmbeddedScaffolderWorkflowProps = Omit<
   finishPage?: ReactNode;
   onError(error: Error | undefined): JSX.Element | null;
   onCreate?: (values: Record<string, JsonValue>) => Promise<void>;
+  useSecrets?: () => ScaffolderUseTemplateSecrets;
   children?: ReactNode;
 };
 
@@ -58,9 +60,10 @@ export function EmbeddedScaffolderWorkflow({
   frontPage,
   onCreate = async (_values: OnCompleteArgs) => void 0,
   children = <></>,
+  useSecrets = useTemplateSecrets,
   ...props
 }: EmbeddedScaffolderWorkflowProps): JSX.Element {
-  const { secrets } = useTemplateSecrets();
+  const { secrets } = useSecrets();
   const scaffolderApi = useApi(scaffolderApiRef);
   const navigate = useNavigate();
   const customFieldExtensions =


### PR DESCRIPTION
## Motivation

The backstage embedded workflow has it's own secrets context. The embedded workflow wrapper here also expects a secrets context, but it is a parent of the backstage embedded scaffolder. The multiple context are both confusing and cause bugs when passing secrets between the forms and the create step.

## Approach

For this situation, I think we may want to see if we can remove the need for this wrapper, or otherwise allow passing a context to the backstage embedded scaffolder or a flag to remove it as an upstream PR. This PR adds the `useSecrets` as a prop that the wrapper can draw from a root secrets context. This also requires any scaffolder form components to use this same context when setting secrets, but seems to be the best workaround until we can establish a longer term solution.
