### PR TITLE
Moved all styles to makeStyle and gave style a name

### DIFF
--- a/.changeset/strong-drinks-visit.md
+++ b/.changeset/strong-drinks-visit.md
@@ -2,4 +2,9 @@
 '@frontside/backstage-plugin-scaffolder-workflow': patch
 ---
 
-Make TaskProgress styles overwrittable
+To fix a bug in one of our client's Backstage sites that use EmbeddedScaffolder where the results page doesn't show the logs. This is happening because the page doesn't properly take full height and automatically adjust the height of the log area. 
+
+1. Use `makeStyles` to create a style that can be overwritten by ovewritting style name `EmbeddedScaffolderTaskProgress`
+2. Added padding bottom to TaskSteps to separate it from step output
+3. Added `flexGrow: 2` to log container box
+4. Added export for EmbeddedScaffolderOverrides with types for TaskProgress

--- a/.changeset/strong-drinks-visit.md
+++ b/.changeset/strong-drinks-visit.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-scaffolder-workflow': patch
+---
+
+Make TaskProgress styles overwrittable

--- a/plugins/scaffolder-frontend-workflow/src/components/TaskProgress/TaskProgress.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/TaskProgress/TaskProgress.tsx
@@ -13,7 +13,7 @@ import { ErrorPanel } from '@backstage/core-components';
 const useStyles = makeStyles(
   theme => {
     return {
-      contentWrapper: {
+      root: {
         display: 'flex',
         flexDirection: 'column',
         height: '100%',
@@ -37,6 +37,8 @@ const useStyles = makeStyles(
     name: 'EmbeddedScaffolderTaskProgress',
   },
 );
+
+export type TaskProgressClassKey = 'root' | 'errorBox' | 'taskStepsBox' | 'logStreamPaper';
 
 export function TaskProgress(): JSX.Element {
   const classes = useStyles();
@@ -65,7 +67,7 @@ export function TaskProgress(): JSX.Element {
   }, [steps]);
 
   return (
-    <Box className={classes.contentWrapper}>
+    <Box className={classes.root}>
       {taskStream.error && (
         <Box className={classes.errorBox}>
           <ErrorPanel

--- a/plugins/scaffolder-frontend-workflow/src/components/TaskProgress/TaskProgress.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/TaskProgress/TaskProgress.tsx
@@ -27,15 +27,8 @@ const useStyles = makeStyles(
       taskStepsBox: {
         paddingBottom: theme.spacing(2),
       },
-      logStreamOuterBox: {
-        flexGrow: 2,
-        paddingBottom: theme.spacing(2),
-      },
       logStreamPaper: {
-        height: '100%',
-      },
-      logStreamInnerBox: {
-        height: '100%',
+        flexGrow: 2,
         padding: theme.spacing(2),
       },
     };
@@ -94,13 +87,9 @@ export function TaskProgress(): JSX.Element {
         <Outputs output={taskStream.output} />
       )}
 
-      <Box className={classes.logStreamOuterBox}>
-        <Paper className={classes.logStreamPaper}>
-          <Box className={classes.logStreamInnerBox}>
-            <TaskLogStream logs={taskStream.stepLogs} />
-          </Box>
-        </Paper>
-      </Box>
+      <Paper className={classes.logStreamPaper}>
+        <TaskLogStream logs={taskStream.stepLogs} />
+      </Paper>
     </Box>
   );
 }

--- a/plugins/scaffolder-frontend-workflow/src/components/TaskProgress/TaskProgress.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/TaskProgress/TaskProgress.tsx
@@ -2,20 +2,48 @@ import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { assert } from 'assert-ts';
 import { useTaskEventStream } from '@backstage/plugin-scaffolder-react';
-import { TaskLogStream, TaskSteps } from '@backstage/plugin-scaffolder-react/alpha'
+import {
+  TaskLogStream,
+  TaskSteps,
+} from '@backstage/plugin-scaffolder-react/alpha';
 import { Box, makeStyles, Paper } from '@material-ui/core';
 import { DefaultTemplateOutputs as Outputs } from '@backstage/plugin-scaffolder-react/alpha';
 import { ErrorPanel } from '@backstage/core-components';
 
-const useStyles = makeStyles({
-  contentWrapper: {
-    display: 'flex',
-    flexDirection: 'column',
-    '& [class^="MuiPaper-root"]:nth-child(2)': {
-      overflow: 'visible !important'
-    }
+const useStyles = makeStyles(
+  theme => {
+    return {
+      contentWrapper: {
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        '& [class^="MuiPaper-root"]:nth-child(2)': {
+          overflow: 'visible !important',
+        },
+      },
+      errorBox: {
+        paddingBottom: theme.spacing(2),
+      },
+      taskStepsBox: {
+        paddingBottom: theme.spacing(2),
+      },
+      logStreamOuterBox: {
+        flexGrow: 2,
+        paddingBottom: theme.spacing(2),
+      },
+      logStreamPaper: {
+        height: '100%',
+      },
+      logStreamInnerBox: {
+        height: '100%',
+        padding: theme.spacing(2),
+      },
+    };
   },
-});
+  {
+    name: 'EmbeddedScaffolderTaskProgress',
+  },
+);
 
 export function TaskProgress(): JSX.Element {
   const classes = useStyles();
@@ -44,9 +72,9 @@ export function TaskProgress(): JSX.Element {
   }, [steps]);
 
   return (
-    <Box height="100%" className={classes.contentWrapper}>
+    <Box className={classes.contentWrapper}>
       {taskStream.error && (
-        <Box paddingBottom={2}>
+        <Box className={classes.errorBox}>
           <ErrorPanel
             error={taskStream.error}
             title={taskStream.error.message}
@@ -54,13 +82,21 @@ export function TaskProgress(): JSX.Element {
         </Box>
       )}
 
-      <TaskSteps isComplete={taskStream.completed} steps={steps} activeStep={activeStep} />
+      <Box className={classes.taskStepsBox}>
+        <TaskSteps
+          isComplete={taskStream.completed}
+          steps={steps}
+          activeStep={activeStep}
+        />
+      </Box>
 
-      <Outputs output={taskStream.output} />
+      {taskStream.output && (
+        <Outputs output={taskStream.output} />
+      )}
 
-      <Box paddingBottom={2} height="100%">
-        <Paper style={{ height: '100%'}}>
-          <Box padding={2} height="100%">
+      <Box className={classes.logStreamOuterBox}>
+        <Paper className={classes.logStreamPaper}>
+          <Box className={classes.logStreamInnerBox}>
             <TaskLogStream logs={taskStream.stepLogs} />
           </Box>
         </Paper>

--- a/plugins/scaffolder-frontend-workflow/src/index.ts
+++ b/plugins/scaffolder-frontend-workflow/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components/EmbeddedScaffolderWorkflow';
+export * from './types';

--- a/plugins/scaffolder-frontend-workflow/src/types.ts
+++ b/plugins/scaffolder-frontend-workflow/src/types.ts
@@ -1,0 +1,13 @@
+import { Overrides } from "@material-ui/core/styles/overrides";
+import { TaskProgressClassKey } from "./components/TaskProgress/TaskProgress";
+import { StyleRules } from "@material-ui/core";
+
+export type PluginEmbeddedScaffolderComponentsNameToClassKey = {
+  TaskProgress: TaskProgressClassKey;
+}
+
+export type EmbeddedScaffolderOverrides = Overrides & {
+  [Name in keyof PluginEmbeddedScaffolderComponentsNameToClassKey]?: Partial<
+    StyleRules<PluginEmbeddedScaffolderComponentsNameToClassKey[Name]>
+  >
+}


### PR DESCRIPTION
## Motivation

I'm working on fixing a bug in one of our client's Backstage sites that use EmbeddedScaffolder where the results page doesn't show the logs. This is happening because the page doesn't properly take full height and automatically adjust the height of the log area. 

## Approach

1. Use `makeStyles` to create a style that can be overwritten by ovewritting style name `EmbeddedScaffolderTaskProgress`
2. Added padding bottom to TaskSteps to separate it from step output
3. Added `flexGrow: 2` to log container box
4. Added export for EmbeddedScaffolderOverrides with types for TaskProgress
 
## Screenshots

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/74687/235801563-25169fb3-1650-4f66-a840-5e735965ef56.png">
