### PR TITLE
Renamed name of the override to match the name in the component

### DIFF
--- a/.changeset/thin-years-switch.md
+++ b/.changeset/thin-years-switch.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-scaffolder-workflow': patch
+---
+
+Renamed override type to match actual name EmbeddedScaffolderTaskProgress

--- a/plugins/scaffolder-frontend-workflow/src/types.ts
+++ b/plugins/scaffolder-frontend-workflow/src/types.ts
@@ -3,7 +3,7 @@ import { TaskProgressClassKey } from "./components/TaskProgress/TaskProgress";
 import { StyleRules } from "@material-ui/core";
 
 export type PluginEmbeddedScaffolderComponentsNameToClassKey = {
-  TaskProgress: TaskProgressClassKey;
+  EmbeddedScaffolderTaskProgress: TaskProgressClassKey;
 }
 
 export type EmbeddedScaffolderOverrides = Overrides & {


### PR DESCRIPTION
## Motivation

I incorrectly named the key in overrides - it should be same EmbeddedScaffolderTaskProgress

## Approach

Rename the key to EmbeddedScaffolderTaskProgress