### PR TITLE
Unwrap LogViewer to make it easier to style

### DIFF
--- a/.changeset/rare-baboons-help.md
+++ b/.changeset/rare-baboons-help.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-scaffolder-workflow': patch
+---
+
+Unwrap LogViewer component to eliminate extra div

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -193,7 +193,6 @@ const websiteEntityPage = (
     </EntityLayout.Route>
 
     <EntityLayout.Route path="/docs" title="Docs">
-      {/* {techdocsContent} */}
       <EntityOnboardingWorkflow
         title="Start using TechDocs"
         description="Showing documentation in this tab requires an annotation to be added to the metadata. 

--- a/plugins/scaffolder-frontend-workflow/src/components/TaskProgress/TaskProgress.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/TaskProgress/TaskProgress.tsx
@@ -2,13 +2,10 @@ import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { assert } from 'assert-ts';
 import { useTaskEventStream } from '@backstage/plugin-scaffolder-react';
-import {
-  TaskLogStream,
-  TaskSteps,
-} from '@backstage/plugin-scaffolder-react/alpha';
+import { TaskSteps } from '@backstage/plugin-scaffolder-react/alpha';
 import { Box, makeStyles, Paper } from '@material-ui/core';
 import { DefaultTemplateOutputs as Outputs } from '@backstage/plugin-scaffolder-react/alpha';
-import { ErrorPanel } from '@backstage/core-components';
+import { ErrorPanel, LogViewer } from '@backstage/core-components';
 
 const useStyles = makeStyles(
   theme => {
@@ -90,7 +87,12 @@ export function TaskProgress(): JSX.Element {
       )}
 
       <Paper className={classes.logStreamPaper}>
-        <TaskLogStream logs={taskStream.stepLogs} />
+        <LogViewer
+          text={Object.values(taskStream.stepLogs)
+            .map(l => l.join('\n'))
+            .filter(Boolean)
+            .join('\n')}
+        />
       </Paper>
     </Box>
   );


### PR DESCRIPTION
## Motivation

The LogViewer is wrapped in an element that only adds `height: 100%`, `width: 100%`, and `position: relative`. This wrapper causes problems in a flex layout.

## Approach

Remove the wrapper and use LogViewer directly
