### PR TITLE
Make actions package not private

### DIFF
--- a/plugins/scaffolder-yaml-actions/package.json
+++ b/plugins/scaffolder-yaml-actions/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Motivation

We want the publishing to actually publish which requires package.json not to have `private: true`. 

## Approach

Remove `private: true` from package.json
