### PR TITLE
Using Workflow instead of EmbeddedWorkflow to eliminate the extra Secret Context Provider

### DIFF
--- a/.changeset/smooth-poets-play.md
+++ b/.changeset/smooth-poets-play.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-scaffolder-workflow': minor
+---
+
+Rely on App provided Scaffolder Secret Context

--- a/plugins/scaffolder-frontend-workflow/src/components/EmbeddedScaffolderWorkflow/EmbeddedScaffolderWorkflow.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/EmbeddedScaffolderWorkflow/EmbeddedScaffolderWorkflow.tsx
@@ -6,10 +6,9 @@ import {
   useCustomLayouts,
   useTemplateSecrets,
   ScaffolderTaskOutput,
-  ScaffolderUseTemplateSecrets,
 } from '@backstage/plugin-scaffolder-react';
 import {
-  EmbeddableWorkflow,
+  Workflow,
   type NextFieldExtensionOptions,
   type WorkflowProps,
 } from '@backstage/plugin-scaffolder-react/alpha';
@@ -33,7 +32,6 @@ export type EmbeddedScaffolderWorkflowProps = Omit<
   finishPage?: ReactNode;
   onError(error: Error | undefined): JSX.Element | null;
   onCreate?: (values: Record<string, JsonValue>) => Promise<void>;
-  useSecrets?: () => ScaffolderUseTemplateSecrets;
   children?: ReactNode;
 };
 
@@ -60,10 +58,9 @@ export function EmbeddedScaffolderWorkflow({
   frontPage,
   onCreate = async (_values: OnCompleteArgs) => void 0,
   children = <></>,
-  useSecrets = useTemplateSecrets,
   ...props
 }: EmbeddedScaffolderWorkflowProps): JSX.Element {
-  const { secrets } = useSecrets();
+  const { secrets } = useTemplateSecrets();
   const scaffolderApi = useApi(scaffolderApiRef);
   const navigate = useNavigate();
   const customFieldExtensions =
@@ -109,7 +106,7 @@ export function EmbeddedScaffolderWorkflow({
           path={frontPage ? 'form' : undefined}
           index={!frontPage}
           element={
-            <EmbeddableWorkflow
+            <Workflow
               onCreate={onWorkFlowCreate}
               extensions={customFieldExtensions}
               layouts={customLayouts}


### PR DESCRIPTION
## Motivation

`EmbeddedWorkflow` has its own context provider. It makes it difficult to set the secrets outside of the components.

## Approach

Using `Workflow` instead of `EmbeddedWorkflow` instead.