### PR TITLE
Include complete host in repoUrl

### DIFF
--- a/.changeset/afraid-years-fail.md
+++ b/.changeset/afraid-years-fail.md
@@ -1,0 +1,5 @@
+---
+'@frontside/scaffolder-yaml-actions': patch
+---
+
+Include complete host in repoUrl

--- a/plugins/scaffolder-yaml-actions/src/actions/set.ts
+++ b/plugins/scaffolder-yaml-actions/src/actions/set.ts
@@ -54,7 +54,7 @@ export function createYamlSetAction({
     async handler(ctx) {
       const { url, entityRef, path, value } = ctx.input;
 
-      const { filepath, source, owner, name } = parseGitUrl(url);
+      const { filepath, resource, owner, name } = parseGitUrl(url);
 
       const sourceFilepath = resolveSafeChildPath(ctx.workspacePath, filepath);
 
@@ -84,7 +84,7 @@ export function createYamlSetAction({
 
       await fs.writeFile(sourceFilepath, updated);
 
-      ctx.output('repoUrl', `${source}?repo=${name}&owner=${owner}`);
+      ctx.output('repoUrl', `${resource}?repo=${name}&owner=${owner}`);
       ctx.output('filePath', filepath);
       ctx.output('path', _path.dirname(sourceFilepath));
     },


### PR DESCRIPTION
## Motivation

We had a report that `repoUrl` needed to be generated correctly in `yaml:set` action - the subdomain was being cutoff.

## Approach

Use `resource` instead of `source` which includes the subdomain

Test of this change in here https://runkit.com/taras/647e0067681fae00089c9a4c