### PR TITLE
ingestion test logPrefix arg

### DIFF
--- a/.changeset/yellow-goats-invent.md
+++ b/.changeset/yellow-goats-invent.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-ingestion-tests': minor
+---
+
+The ingestion test logs were dropped into a logs folder and every test would overwrite the file. This adds an option to pass an additional prefix which allows per file, per suite and/or per test log files irrespective of the test runner.

--- a/packages/ingestion-tests/src/harness.ts
+++ b/packages/ingestion-tests/src/harness.ts
@@ -33,6 +33,7 @@ export interface BackstageHarness {
 
 export function createBackstageHarness(
   npmScript: string,
+  logPrefix: string,
   ...configs: JsonObject[]
 ): BackstageHarness {
   assert(!!npmScript, 'you must supply an npm script e.g. yarn workspace backend start')
@@ -49,22 +50,22 @@ export function createBackstageHarness(
       const logs: ProcessLog[] = [
         yield createProcessLog({
           name: 'HttpRequestLogger',
-          path: `logs/http`,
+          path: `logs/${logPrefix}http`,
           pluginId: 'backstage',
         }),
         yield createProcessLog({
           name: 'CatalogLogger',
-          path: `logs/catalog`,
+          path: `logs/${logPrefix}catalog`,
           pluginId: 'catalog',
         }),
         yield createProcessLog({
           name: 'SearchLogger',
-          path: `logs/search`,
+          path: `logs/${logPrefix}search`,
           pluginId: 'search',
         }),
         yield createProcessLog({
           name: 'BackstageFirehoseLogger',
-          path: 'logs/firehose',
+          path: `logs/${logPrefix}firehose`,
         }),
       ];
 


### PR DESCRIPTION
## Motivation

We want the ingestion tests to be capable of keeping a log for each test run.

## Approach

I looked at trying to keep this backward compatible, but the args and types are making it pretty difficult. I think the current user base will be amenable to adjusting to this breaking change. The "prefix" option seemed the best as it gives the user control over how they want to overwrite the log files per test run (or not at all), and will work with any test runner.
