### PR TITLE
allow customizing embedded workflow form directly

### DIFF
--- a/.changeset/selfish-foxes-live.md
+++ b/.changeset/selfish-foxes-live.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-scaffolder-workflow': minor
+---
+
+Expose the FormComponent to improve ability to customize the DOM layout and styling.

--- a/plugins/scaffolder-frontend-workflow/src/components/Form/RJSFForm.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/Form/RJSFForm.tsx
@@ -1,3 +1,5 @@
-import { withTheme } from '@rjsf/core-v5';
+import { withTheme, FormProps } from '@rjsf/core-v5';
 
 export const RJSFForm = withTheme(require('@rjsf/material-ui-v5').Theme);
+
+export type RJSFFormProps = Pick<FormProps, 'transformErrors' | 'extraErrors' | 'className' | 'ref'>;

--- a/plugins/scaffolder-frontend-workflow/src/components/Form/index.ts
+++ b/plugins/scaffolder-frontend-workflow/src/components/Form/index.ts
@@ -1,2 +1,2 @@
 export * from './Form';
-export * from './Workflow';
+export * from './RJSFForm';

--- a/plugins/scaffolder-frontend-workflow/src/components/ModalWorkflow/ModalWorkflow.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/ModalWorkflow/ModalWorkflow.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import { type WorkflowProps } from '@backstage/plugin-scaffolder-react/alpha';
 import { Modal, ModalProps } from '../Modal/Modal';
-import { Workflow } from '../Form/Workflow';
+import { Workflow } from '../Workflow';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { useRunWorkflow, useWorkflowManifest } from '../../hooks';
 

--- a/plugins/scaffolder-frontend-workflow/src/components/Workflow/Workflow.test.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/Workflow/Workflow.test.tsx
@@ -1,0 +1,134 @@
+import {
+  MockAnalyticsApi,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/test-utils';
+import { act, fireEvent, RenderResult } from '@testing-library/react';
+import React from 'react';
+import {
+  scaffolderApiRef,
+  SecretsContextProvider,
+} from '@backstage/plugin-scaffolder-react';
+import { analyticsApiRef } from '@backstage/core-plugin-api';
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { ScaffolderWorkflow } from '../../test.components';
+import { scaffolderApiMock } from '../../test.utils';
+
+const analyticsMock = new MockAnalyticsApi();
+
+describe('<Workflow />', () => {
+  let rendered: RenderResult;
+  beforeEach(async () => {
+    scaffolderApiMock.scaffold.mockResolvedValue({ taskId: 'xyz' });
+
+    scaffolderApiMock.getTemplateParameterSchema.mockResolvedValue({
+      steps: [
+        {
+          title: 'Step 1',
+          schema: {
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      ],
+      title: 'React JSON Schema Form Test',
+    });
+
+    rendered = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [scaffolderApiRef, scaffolderApiMock],
+          [analyticsApiRef, analyticsMock],
+        ]}
+      >
+        <SecretsContextProvider>
+          <ScaffolderWorkflow
+            templateName="docs-template"
+            namespace="default"
+          />
+        </SecretsContextProvider>
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/create': scaffolderPlugin.routes.root,
+          '/create-legacy': scaffolderPlugin.routes.root,
+        },
+      },
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('advances through form and submits', async () => {
+    const { getByRole, getByText } = rendered;
+    expect(getByRole('textbox').innerHTML).toBeDefined();
+
+    // const input = getByRole('textbox') as HTMLInputElement;
+
+    // // The initial state of the form can be set
+    // expect(input.value).toBe('prefilled-name');
+
+    expect(getByText('Step 1')).toBeDefined();
+
+    const reviewButton = getByRole('button', {
+      name: 'Review',
+    }) as HTMLButtonElement;
+
+    await act(async () => {
+      fireEvent.click(reviewButton);
+    });
+
+    expect(getByText('Review Page') as HTMLButtonElement).toBeDefined();
+
+    const createButton = getByRole('button', {
+      name: 'Create',
+    }) as HTMLButtonElement;
+
+    await act(async () => {
+      fireEvent.click(createButton);
+    });
+
+    expect(scaffolderApiMock.scaffold).toHaveBeenCalled();
+  });
+
+  it('goes back from review state and has form data', async () => {
+    const { getByRole, getByText } = rendered;
+    expect(getByRole('textbox').innerHTML).toBeDefined();
+
+    const input = getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'boop' } });
+
+    // // The initial state of the form can be set
+    // expect(input.value).toBe('prefilled-name');
+
+    expect(getByText('Step 1')).toBeDefined();
+
+    const reviewButton = getByRole('button', {
+      name: 'Review',
+    }) as HTMLButtonElement;
+
+    await act(async () => {
+      fireEvent.click(reviewButton);
+    });
+
+    expect(getByText('Review Page') as HTMLButtonElement).toBeDefined();
+
+    const backButton = getByRole('button', {
+      name: 'Back',
+    }) as HTMLButtonElement;
+
+    await act(async () => {
+      fireEvent.click(backButton);
+    });
+
+    expect(scaffolderApiMock.scaffold).not.toHaveBeenCalled();
+
+    const inputSame = getByRole('textbox') as HTMLInputElement;
+    expect(inputSame.value).toBe('boop');
+  });
+});

--- a/plugins/scaffolder-frontend-workflow/src/components/Workflow/Workflow.test.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/Workflow/Workflow.test.tsx
@@ -17,118 +17,191 @@ import { scaffolderApiMock } from '../../test.utils';
 const analyticsMock = new MockAnalyticsApi();
 
 describe('<Workflow />', () => {
-  let rendered: RenderResult;
-  beforeEach(async () => {
-    scaffolderApiMock.scaffold.mockResolvedValue({ taskId: 'xyz' });
-
-    scaffolderApiMock.getTemplateParameterSchema.mockResolvedValue({
-      steps: [
-        {
-          title: 'Step 1',
-          schema: {
-            properties: {
-              name: {
-                type: 'string',
-              },
-            },
-          },
-        },
-      ],
-      title: 'React JSON Schema Form Test',
-    });
-
-    rendered = await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [scaffolderApiRef, scaffolderApiMock],
-          [analyticsApiRef, analyticsMock],
-        ]}
-      >
-        <SecretsContextProvider>
-          <ScaffolderWorkflow
-            templateName="docs-template"
-            namespace="default"
-          />
-        </SecretsContextProvider>
-      </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/create': scaffolderPlugin.routes.root,
-          '/create-legacy': scaffolderPlugin.routes.root,
-        },
-      },
-    );
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('advances through form and submits', async () => {
-    const { getByRole, getByText } = rendered;
-    expect(getByRole('textbox').innerHTML).toBeDefined();
+  describe('with default form component', () => {
+    let rendered: RenderResult;
+    beforeEach(async () => {
+      scaffolderApiMock.scaffold.mockResolvedValue({ taskId: 'xyz' });
 
-    // const input = getByRole('textbox') as HTMLInputElement;
+      scaffolderApiMock.getTemplateParameterSchema.mockResolvedValue({
+        steps: [
+          {
+            title: 'Step 1',
+            schema: {
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        ],
+        title: 'React JSON Schema Form Test',
+      });
 
-    // // The initial state of the form can be set
-    // expect(input.value).toBe('prefilled-name');
-
-    expect(getByText('Step 1')).toBeDefined();
-
-    const reviewButton = getByRole('button', {
-      name: 'Review',
-    }) as HTMLButtonElement;
-
-    await act(async () => {
-      fireEvent.click(reviewButton);
+      rendered = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [scaffolderApiRef, scaffolderApiMock],
+            [analyticsApiRef, analyticsMock],
+          ]}
+        >
+          <SecretsContextProvider>
+            <ScaffolderWorkflow
+              templateName="docs-template"
+              namespace="default"
+              FormProps={{ className: 'this-form-has-class' }}
+            />
+          </SecretsContextProvider>
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/create': scaffolderPlugin.routes.root,
+            '/create-legacy': scaffolderPlugin.routes.root,
+          },
+        },
+      );
     });
 
-    expect(getByText('Review Page') as HTMLButtonElement).toBeDefined();
-
-    const createButton = getByRole('button', {
-      name: 'Create',
-    }) as HTMLButtonElement;
-
-    await act(async () => {
-      fireEvent.click(createButton);
+    afterEach(() => {
+      jest.clearAllMocks();
     });
 
-    expect(scaffolderApiMock.scaffold).toHaveBeenCalled();
+    it('advances through form and submits', async () => {
+      const { getByRole, getByText } = rendered;
+      expect(getByRole('textbox').innerHTML).toBeDefined();
+
+      // const input = getByRole('textbox') as HTMLInputElement;
+
+      // // The initial state of the form can be set
+      // expect(input.value).toBe('prefilled-name');
+
+      expect(getByText('Step 1')).toBeDefined();
+
+      const reviewButton = getByRole('button', {
+        name: 'Review',
+      }) as HTMLButtonElement;
+
+      await act(async () => {
+        fireEvent.click(reviewButton);
+      });
+
+      expect(getByText('Review Page') as HTMLButtonElement).toBeDefined();
+
+      const createButton = getByRole('button', {
+        name: 'Create',
+      }) as HTMLButtonElement;
+
+      await act(async () => {
+        fireEvent.click(createButton);
+      });
+
+      expect(scaffolderApiMock.scaffold).toHaveBeenCalledTimes(1);
+    });
+
+    it('goes back from review state and has form data', async () => {
+      const { getByRole, getByText } = rendered;
+      expect(getByRole('textbox').innerHTML).toBeDefined();
+
+      const input = getByRole('textbox') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'boop' } });
+
+      // // The initial state of the form can be set
+      // expect(input.value).toBe('prefilled-name');
+
+      expect(getByText('Step 1')).toBeDefined();
+
+      const reviewButton = getByRole('button', {
+        name: 'Review',
+      }) as HTMLButtonElement;
+
+      await act(async () => {
+        fireEvent.click(reviewButton);
+      });
+
+      expect(getByText('Review Page') as HTMLButtonElement).toBeDefined();
+
+      const backButton = getByRole('button', {
+        name: 'Back',
+      }) as HTMLButtonElement;
+
+      await act(async () => {
+        fireEvent.click(backButton);
+      });
+
+      expect(scaffolderApiMock.scaffold).not.toHaveBeenCalled();
+
+      const inputSame = getByRole('textbox') as HTMLInputElement;
+      expect(inputSame.value).toBe('boop');
+    });
+
+    it('allows passing a className', async () => {
+      const { getByRole, getByText, container } = rendered;
+      expect(getByRole('textbox').innerHTML).toBeDefined();
+
+      const input = getByRole('textbox') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'boop' } });
+
+      expect(getByText('Step 1')).toBeDefined();
+
+      const form = container.querySelector('form') as HTMLFormElement;
+
+      expect(form.className).toBe('this-form-has-class');
+    });
   });
 
-  it('goes back from review state and has form data', async () => {
-    const { getByRole, getByText } = rendered;
-    expect(getByRole('textbox').innerHTML).toBeDefined();
+  describe('with custom form component', () => {
+    let rendered: RenderResult;
+    beforeEach(async () => {
+      scaffolderApiMock.scaffold.mockResolvedValue({ taskId: 'xyz' });
 
-    const input = getByRole('textbox') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: 'boop' } });
+      scaffolderApiMock.getTemplateParameterSchema.mockResolvedValue({
+        steps: [
+          {
+            title: 'Step 1',
+            schema: {
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        ],
+        title: 'React JSON Schema Form Test',
+      });
 
-    // // The initial state of the form can be set
-    // expect(input.value).toBe('prefilled-name');
-
-    expect(getByText('Step 1')).toBeDefined();
-
-    const reviewButton = getByRole('button', {
-      name: 'Review',
-    }) as HTMLButtonElement;
-
-    await act(async () => {
-      fireEvent.click(reviewButton);
+      rendered = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [scaffolderApiRef, scaffolderApiMock],
+            [analyticsApiRef, analyticsMock],
+          ]}
+        >
+          <SecretsContextProvider>
+            <ScaffolderWorkflow
+              templateName="docs-template"
+              namespace="default"
+              FormComponent={() => <form className="placeholder-form" />}
+            />
+          </SecretsContextProvider>
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/create': scaffolderPlugin.routes.root,
+            '/create-legacy': scaffolderPlugin.routes.root,
+          },
+        },
+      );
     });
 
-    expect(getByText('Review Page') as HTMLButtonElement).toBeDefined();
-
-    const backButton = getByRole('button', {
-      name: 'Back',
-    }) as HTMLButtonElement;
-
-    await act(async () => {
-      fireEvent.click(backButton);
+    it('renders a dummy form', async () => {
+      const { container } = rendered;
+      const form = container.querySelector('form') as HTMLFormElement;
+      expect(form.className).toBe('placeholder-form');
     });
-
-    expect(scaffolderApiMock.scaffold).not.toHaveBeenCalled();
-
-    const inputSame = getByRole('textbox') as HTMLInputElement;
-    expect(inputSame.value).toBe('boop');
   });
 });

--- a/plugins/scaffolder-frontend-workflow/src/components/Workflow/Workflow.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/Workflow/Workflow.tsx
@@ -116,7 +116,7 @@ export const Workflow = ({
         handleNext={handleForward}
         step={currentStep}
         extraErrors={stepper.errors as unknown as ErrorSchema}
-        initialState={initialState}
+        initialState={stepper.formState}
         {...FormProps}
       >
         {children}

--- a/plugins/scaffolder-frontend-workflow/src/components/Workflow/index.ts
+++ b/plugins/scaffolder-frontend-workflow/src/components/Workflow/index.ts
@@ -1,0 +1,1 @@
+export * from './Workflow';

--- a/plugins/scaffolder-frontend-workflow/src/components/index.ts
+++ b/plugins/scaffolder-frontend-workflow/src/components/index.ts
@@ -2,4 +2,5 @@ export * from './EmbeddedScaffolderWorkflow';
 export * from './Form';
 export * from './ModalWorkflow/ModalWorkflow';
 export * from './WorkflowButton/WorkflowButton';
-export * from './TaskProgress'
+export * from './TaskProgress';
+export * from './Workflow';

--- a/plugins/scaffolder-frontend-workflow/src/hooks/useRunWorkflow.test.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/hooks/useRunWorkflow.test.tsx
@@ -5,38 +5,8 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import {
   scaffolderApiRef,
   SecretsContextProvider,
-  type ScaffolderApi,
 } from '@backstage/plugin-scaffolder-react';
-
-const scaffolderApiMock: jest.Mocked<ScaffolderApi> = {
-  scaffold: jest
-    .fn()
-    .mockImplementationOnce(() => Promise.resolve({ taskId: 'boop' })),
-  getTemplateParameterSchema: jest.fn(),
-  getIntegrationsList: jest.fn(),
-  getTask: jest.fn().mockImplementationOnce(() =>
-    Promise.resolve({
-      id: 'blam',
-      spec: { steps: [] },
-      status: 'processing',
-      lastHeartbeatAt: '',
-      createdAt: '',
-    }),
-  ),
-  streamLogs: jest.fn().mockImplementationOnce(() => ({
-    subscribe: () => {},
-    next: () => ({
-      type: 'log',
-      body: {},
-      createdAt: '',
-      id: 'blam',
-      taskId: 'boop',
-    }),
-  })),
-  listActions: jest.fn(),
-  listTasks: jest.fn(),
-  cancelTask: jest.fn(),
-};
+import { scaffolderApiMock } from '../test.utils';
 
 describe('useRunWorkflow', () => {
   it('should reset', async () => {

--- a/plugins/scaffolder-frontend-workflow/src/test.components.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/test.components.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+
+import {
+  Stepper,
+  type RunWorkflow,
+  useWorkflowManifest,
+  useRunWorkflow,
+  TaskProgress,
+  Workflow,
+} from '@frontside/backstage-plugin-scaffolder-workflow';
+import {
+  ParsedTemplateSchema,
+  ReviewState,
+} from '@backstage/plugin-scaffolder-react/alpha';
+
+import {
+  Stepper as MuiStepper,
+  Step as MuiStep,
+  StepLabel as MuiStepLabel,
+  Button,
+  makeStyles,
+} from '@material-ui/core';
+import { BackstageTheme } from '@backstage/theme';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { InfoCard, MarkdownContent } from '@backstage/core-components';
+
+const useStyles = makeStyles<BackstageTheme>(theme => ({
+  formWrapper: {
+    padding: theme.spacing(2),
+  },
+  formFooter: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'right',
+    marginTop: theme.spacing(2),
+  },
+  markdown: {
+    /** to make the styles for React Markdown not leak into the description */
+    '& :first-child': {
+      marginTop: 0,
+    },
+    '& :last-child': {
+      marginBottom: 0,
+    },
+  },
+}));
+
+export function ScaffolderWorkflow(props: {
+  templateName: string;
+  namespace?: string;
+}): JSX.Element | null {
+  const styles = useStyles();
+
+  const { loading, manifest } = useWorkflowManifest({
+    name: props.templateName,
+    namespace: props.namespace,
+  });
+
+  const templateRef = stringifyEntityRef({
+    kind: 'Template',
+    namespace: props.namespace,
+    name: props.templateName,
+  });
+
+  const workflow = useRunWorkflow({
+    templateRef,
+  });
+
+  if (loading) {
+    return <>Loading template...</>;
+  }
+
+  return manifest ? (
+    <InfoCard
+      title={manifest.title}
+      subheader={
+        <MarkdownContent
+          className={styles.markdown}
+          content={manifest.description ?? 'No description'}
+        />
+      }
+      noPadding
+      titleTypographyProps={{ component: 'h2' }}
+    >
+      <div className={styles.formWrapper}>
+        <Workflow
+          manifest={manifest}
+          workflow={workflow}
+          initialState={{}}
+          formFooter={<FormActions workflow={workflow} />}
+          stepperProgress={<StepperProgress />}
+          reviewComponent={<EntityReview workflow={workflow} />}
+          children={<></>}
+        />
+      </div>
+      {workflow.taskStream.loading === false && (
+        <TaskProgress taskStream={workflow.taskStream} />
+      )}
+    </InfoCard>
+  ) : null;
+}
+
+export function FormActions({
+  stepper,
+  workflow,
+}: {
+  stepper?: Stepper;
+  workflow: RunWorkflow;
+}) {
+  const styles = useStyles();
+  if (stepper) {
+    const buttonText =
+      stepper.activeStep === stepper.steps.length - 1 ? 'Review' : 'Continue';
+    return (
+      <div className={styles.formFooter}>
+        <Button
+          onClick={stepper.handleBack}
+          disabled={stepper.activeStep < 1 || stepper.isValidating}
+        >
+          Back
+        </Button>
+        {stepper.activeStep === stepper.steps.length ? (
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => workflow?.execute(stepper.formState)}
+            type="button"
+            disabled={workflow?.taskStatus !== 'idle'}
+          >
+            Create
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            color="primary"
+            type="submit"
+            disabled={stepper.isValidating}
+          >
+            {buttonText}
+          </Button>
+        )}
+      </div>
+    );
+  }
+  return null;
+}
+
+export function EntityReview({
+  stepper,
+  workflow,
+}: {
+  stepper?: Stepper;
+  workflow: RunWorkflow;
+}) {
+  const styles = useStyles();
+  if (stepper) {
+    return (
+      <div className={styles.formWrapper}>
+        <h1>Review Page</h1>
+        <ReviewState schemas={stepper.steps} formState={stepper.formState} />
+        <FormActions workflow={workflow} stepper={stepper} />
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export function StepperProgress({
+  activeStep,
+  steps = [],
+}: {
+  activeStep?: number;
+  steps?: ParsedTemplateSchema[];
+}) {
+  return (
+    <MuiStepper activeStep={activeStep} alternativeLabel variant="elevation">
+      {steps.map((step, index) => (
+        <MuiStep key={index}>
+          <MuiStepLabel>{step.title}</MuiStepLabel>
+        </MuiStep>
+      ))}
+      <MuiStep>
+        <MuiStepLabel>Review</MuiStepLabel>
+      </MuiStep>
+    </MuiStepper>
+  );
+}

--- a/plugins/scaffolder-frontend-workflow/src/test.components.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/test.components.tsx
@@ -7,6 +7,8 @@ import {
   useRunWorkflow,
   TaskProgress,
   Workflow,
+  RJSFFormProps,
+  FormProps,
 } from '@frontside/backstage-plugin-scaffolder-workflow';
 import {
   ParsedTemplateSchema,
@@ -48,6 +50,8 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 export function ScaffolderWorkflow(props: {
   templateName: string;
   namespace?: string;
+  FormProps?: RJSFFormProps;
+  FormComponent?: FormProps['Component'];
 }): JSX.Element | null {
   const styles = useStyles();
 
@@ -91,6 +95,8 @@ export function ScaffolderWorkflow(props: {
           stepperProgress={<StepperProgress />}
           reviewComponent={<EntityReview workflow={workflow} />}
           children={<></>}
+          FormProps={props?.FormProps}
+          FormComponent={props?.FormComponent}
         />
       </div>
       {workflow.taskStream.loading === false && (

--- a/plugins/scaffolder-frontend-workflow/src/test.utils.ts
+++ b/plugins/scaffolder-frontend-workflow/src/test.utils.ts
@@ -6,7 +6,7 @@ export const scaffolderApiMock: jest.Mocked<ScaffolderApi> = {
     .mockImplementationOnce(() => Promise.resolve({ taskId: 'boop' })),
   getTemplateParameterSchema: jest.fn(),
   getIntegrationsList: jest.fn(),
-  getTask: jest.fn().mockImplementationOnce(() =>
+  getTask: jest.fn().mockImplementation(() =>
     Promise.resolve({
       id: 'blam',
       spec: { steps: [] },
@@ -15,7 +15,7 @@ export const scaffolderApiMock: jest.Mocked<ScaffolderApi> = {
       createdAt: '',
     }),
   ),
-  streamLogs: jest.fn().mockImplementationOnce(() => ({
+  streamLogs: jest.fn().mockImplementation(() => ({
     subscribe: () => {},
     next: () => ({
       type: 'log',

--- a/plugins/scaffolder-frontend-workflow/src/test.utils.ts
+++ b/plugins/scaffolder-frontend-workflow/src/test.utils.ts
@@ -1,0 +1,31 @@
+import { type ScaffolderApi } from '@backstage/plugin-scaffolder-react';
+
+export const scaffolderApiMock: jest.Mocked<ScaffolderApi> = {
+  scaffold: jest
+    .fn()
+    .mockImplementationOnce(() => Promise.resolve({ taskId: 'boop' })),
+  getTemplateParameterSchema: jest.fn(),
+  getIntegrationsList: jest.fn(),
+  getTask: jest.fn().mockImplementationOnce(() =>
+    Promise.resolve({
+      id: 'blam',
+      spec: { steps: [] },
+      status: 'processing',
+      lastHeartbeatAt: '',
+      createdAt: '',
+    }),
+  ),
+  streamLogs: jest.fn().mockImplementationOnce(() => ({
+    subscribe: () => {},
+    next: () => ({
+      type: 'log',
+      body: {},
+      createdAt: '',
+      id: 'blam',
+      taskId: 'boop',
+    }),
+  })),
+  listActions: jest.fn(),
+  listTasks: jest.fn(),
+  cancelTask: jest.fn(),
+};


### PR DESCRIPTION
## Motivation

We have found there is a greater need to customize the internals of the form. This looks to enable passing `FormProps` and a `FormComponent` as required to adjust the `RJSForm`.

## Approach

Pull up and expose an API to pass `FormProps` and `FormComponent` directly to allow adjusting the form using RSJF props. This also includes tests to confirm this functionality.

Additionally, we addressed an issue where using the `stepper.handleBack` from the review page would result in loss of the `formData`.
