### PR TITLE
Remove @backstage/plugin-scaffolder dependency

### DIFF
--- a/.changeset/unlucky-seahorses-think.md
+++ b/.changeset/unlucky-seahorses-think.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-scaffolder-workflow': patch
+---
+
+Removed unnecessary dependency on@backstage/plugin-scaffolder

--- a/plugins/scaffolder-frontend-workflow/package.json
+++ b/plugins/scaffolder-frontend-workflow/package.json
@@ -25,7 +25,6 @@
     "@backstage/catalog-model": "^1.3.0",
     "@backstage/core-components": "^0.13.1",
     "@backstage/core-plugin-api": "^1.5.1",
-    "@backstage/plugin-scaffolder": "^1.13.1",
     "@backstage/plugin-scaffolder-react": "^1.4.0",
     "@backstage/theme": "^0.3.0",
     "@backstage/types": "^1.0.2",


### PR DESCRIPTION
## Motivation

In https://github.com/backstage/backstage/issues/18314#issuecomment-1597051205, @freben pointed out that we declared @backstage/plugin-scaffolder as a dependency. We're not using that package for anything, so we should remove it.

## Approach

Remove the dependency on @backstage/plugin-scaffolder
