### PR TITLE
Allow passing a path to YAML actions

### DIFF
--- a/.changeset/swift-toys-wait.md
+++ b/.changeset/swift-toys-wait.md
@@ -1,0 +1,6 @@
+---
+'backend': patch
+'@frontside/scaffolder-yaml-actions': patch
+---
+
+Allowed passing a path instead of url in YAML actions

--- a/plugins/scaffolder-yaml-actions/README.md
+++ b/plugins/scaffolder-yaml-actions/README.md
@@ -64,7 +64,7 @@ Set the contents of a YAML document.
 
 **Input:**
 
-* `url` [*string*] - URL of the YAML document [example: https://github.com/backstage/backstage/tree/master/catalog-info.yaml]
+* `url` [*string*] - URL of the YAML file or file system path [example: https://github.com/backstage/backstage/tree/master/catalog-info.yaml]
 * `path` [*string*] - the path of the property to set [example: metadata.name]
 * `value` [*string* | *number* | *null] - value to set
 * entityRef [string, optional] - entity ref of entity to update in case YAML file contains multiple documents
@@ -81,7 +81,7 @@ Append a value to a collection in a YAML document.
 
 **Input:**
 
-* `url` [*string*] - URL of the YAML document [example: https://github.com/backstage/backstage/tree/master/catalog-info.yaml]
+* `url` [*string*] - URL of the YAML file or file system path (relative or absolute) [example: https://github.com/backstage/backstage/tree/master/catalog-info.yaml]
 * `path` [*string*] - the path of the property to update [example: metadata.tags]
 * `value` [*string* | *number* | *null* | *Record<string, any>*] - value to append
 * entityRef [string, optional] - entity ref of entity to update in case YAML file contains multiple documents

--- a/plugins/scaffolder-yaml-actions/src/actions/_helpers.ts
+++ b/plugins/scaffolder-yaml-actions/src/actions/_helpers.ts
@@ -1,0 +1,1 @@
+const isUrl = (maybeUrl: string) => /^(?:[a-z+]+:)?\/\//.test(maybeUrl)

--- a/plugins/scaffolder-yaml-actions/src/actions/_helpers.ts
+++ b/plugins/scaffolder-yaml-actions/src/actions/_helpers.ts
@@ -1,1 +1,1 @@
-const isUrl = (maybeUrl: string) => /^(?:[a-z+]+:)?\/\//.test(maybeUrl)
+export const isUrl = (maybeUrl: string) => /^(?:[a-z+]+:)?\/\//.test(maybeUrl)

--- a/plugins/scaffolder-yaml-actions/src/actions/append.ts
+++ b/plugins/scaffolder-yaml-actions/src/actions/append.ts
@@ -9,6 +9,7 @@ import _path from 'path';
 import { Logger } from 'winston';
 import { z } from 'zod';
 import { append } from '../operations/append';
+import { isUrl } from './_helpers';
 
 interface CreateYamAppendActionOptions {
   logger: Logger;
@@ -18,7 +19,7 @@ interface CreateYamAppendActionOptions {
 }
 
 const InputSchema = z.object({
-  url: z.string().describe('URL of the YAML file to update'),
+  url: z.string().describe('URL of the YAML file to set or file system path (relative or absolute)'),
   path: z.string().describe('The path of the collection to append to'),
   value: z
     .union([z.string(), z.number(), z.null(), z.record(z.any())])

--- a/plugins/scaffolder-yaml-actions/src/actions/set.ts
+++ b/plugins/scaffolder-yaml-actions/src/actions/set.ts
@@ -9,6 +9,7 @@ import _path from 'path';
 import { Logger } from 'winston';
 import { z } from 'zod';
 import { set } from '../operations/set';
+import { isUrl } from './_helpers';
 
 interface CreateYamlSetActionOptions {
   logger: Logger;
@@ -18,7 +19,7 @@ interface CreateYamlSetActionOptions {
 }
 
 const InputSchema = z.object({
-  url: z.string().describe('URL of the YAML file to set'),
+  url: z.string().describe('URL of the YAML file to set or file system path (relative or absolute)'),
   path: z.string().describe('The path of the property to set'),
   value: z
     .union([z.string(), z.number(), z.null()])

--- a/plugins/scaffolder-yaml-actions/src/actions/set.ts
+++ b/plugins/scaffolder-yaml-actions/src/actions/set.ts
@@ -52,18 +52,28 @@ export function createYamlSetAction({
     async handler(ctx) {
       const { url, entityRef, path, value } = ctx.input;
 
-      const { filepath, resource, owner, name } = parseGitUrl(url);
+      let sourceFilepath;
+      if (isUrl(url)) {
+        const { filepath, resource, owner, name } = parseGitUrl(url);
 
-      const sourceFilepath = resolveSafeChildPath(ctx.workspacePath, filepath);
+        // This should be removed in favour of using fetch:plain:file
+        // FIX: blocked by https://github.com/backstage/backstage/issues/17072
+        await fetchAction.handler({
+          ...ctx,
+          input: {
+            url: _path.dirname(ctx.input.url),
+          },
+        });
 
-      // This should be removed in favour of using fetch:plain:file
-      // FIX: blocked by https://github.com/backstage/backstage/issues/17072
-      await fetchAction.handler({
-        ...ctx,
-        input: {
-          url: _path.dirname(ctx.input.url),
-        },
-      });
+        sourceFilepath = resolveSafeChildPath(ctx.workspacePath, filepath);
+
+        ctx.output('repoUrl', `${resource}?repo=${name}&owner=${owner}`);
+        ctx.output('filePath', filepath);
+      } else if (_path.isAbsolute(url)) {
+        sourceFilepath = url;
+      } else {
+        sourceFilepath = resolveSafeChildPath(ctx.workspacePath, url);
+      }
 
       let content;
       try {
@@ -82,9 +92,8 @@ export function createYamlSetAction({
 
       await fs.writeFile(sourceFilepath, updated);
 
-      ctx.output('repoUrl', `${resource}?repo=${name}&owner=${owner}`);
-      ctx.output('filePath', filepath);
       ctx.output('path', _path.dirname(sourceFilepath));
+      ctx.output('sourceFilepath', sourceFilepath);
     },
   });
 }


### PR DESCRIPTION
## Motivation

The original YAML actions were designed to change YAML documents using URLs from source location annotation. Modifying files from the file system without cloning the repository would be helpful.

## Approach

Allow the `url` argument to be a relative or absolute path in addition to a regular url.

1. Deletect if a URL in which case it executed previous logic
2. When not a URL, for a relative path, calculate path by appending to the workspace directory
3. When not a URL, for an absolute path, just read the file from the absolute path.
