### PR TITLE
Deprecating our ingestion backend plugin

### DIFF
--- a/plugins/incremental-ingestion-backend/README.md
+++ b/plugins/incremental-ingestion-backend/README.md
@@ -1,5 +1,7 @@
 # backend-incremental-ingestion
 
+> :warning: This package is deprecated in favour of [**@backstage/plugin-catalog-backend-module-incremental-ingestion**](https://www.npmjs.com/package/@backstage/plugin-catalog-backend-module-incremental-ingestion)
+
 The Incremental Ingestion Backend plugin provides an Incremental Entity Provider that can be used to ingest data from sources using delta mutations, while retaining the orphan prevention mechanism provided by full mutations.
 
 ## Why did we create it?

--- a/plugins/incremental-ingestion-backend/package.json
+++ b/plugins/incremental-ingestion-backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@frontside/backstage-plugin-incremental-ingestion-backend",
   "version": "0.4.6",
+  "deprecated": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Motivation

`@backstage/plugin-catalog-backend-module-incremental-ingestion` is the official incremental ingestion backend. Keeping this package just causes confusion.

## Approach

Add `deprecated` flag to package.json 🤞 it'll do the thing