### PR TITLE
It should say "deprecate" not "deprecated"

### DIFF
--- a/plugins/incremental-ingestion-backend/package.json
+++ b/plugins/incremental-ingestion-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontside/backstage-plugin-incremental-ingestion-backend",
   "version": "0.4.6",
-  "deprecated": true,
+  "deprecate": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Motivation

In #341, the flag was incorrectly set, so I want to fix it. 

## Approach

Replace `deprecated` with `deprecate`