### PR TITLE
Revert "It should say "deprecate" not "deprecated""

### DIFF
--- a/plugins/incremental-ingestion-backend/package.json
+++ b/plugins/incremental-ingestion-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontside/backstage-plugin-incremental-ingestion-backend",
   "version": "0.4.6",
-  "deprecate": true,
+  "deprecated": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Reverts thefrontside/playhouse#342 because the publish action is broken, and it's going to prevent other packages from publishing.