### PR TITLE
fix(yaml-actions): Update entity by metadata name

### DIFF
--- a/.changeset/tough-keys-reflect.md
+++ b/.changeset/tough-keys-reflect.md
@@ -1,0 +1,5 @@
+---
+'@frontside/scaffolder-yaml-actions': patch
+---
+
+Support entity updates by metadata name

--- a/plugins/scaffolder-yaml-actions/src/operations/append.test.ts
+++ b/plugins/scaffolder-yaml-actions/src/operations/append.test.ts
@@ -15,7 +15,7 @@ describe('append', () => {
   it("creates collection when it doesn't exist", () => {
     expect(append({
       content: `metadata:
-        foo: 
+        foo:
         `,
       path: 'metadata.tags',
       value: 'production'
@@ -23,6 +23,30 @@ describe('append', () => {
   foo:
   tags:
     - production
+`)
+  });
+  it('adds to the resource entity', () => {
+    expect(append({
+      content: `metadata:
+        name: entity-a
+kind: component
+---
+metadata:
+        name: entity-b
+kind: resource
+        `,
+      path: 'metadata.tags',
+      value: 'production',
+      entityRef: 'resource:default/entity-b'
+    })).toEqual(`metadata:
+  name: entity-a
+kind: component
+---
+metadata:
+  name: entity-b
+  tags:
+    - production
+kind: resource
 `)
   });
 });

--- a/plugins/scaffolder-yaml-actions/src/operations/append.ts
+++ b/plugins/scaffolder-yaml-actions/src/operations/append.ts
@@ -19,7 +19,7 @@ export function append({
     const maybeEntity = document.contents.toJSON();
 
     if (typeof maybeEntity.kind === 'string' &&
-      typeof maybeEntity.name === 'string' &&
+    (typeof maybeEntity.name === 'string' || typeof maybeEntity.metadata?.name === 'string') &&
       entityRef &&
       stringifyEntityRef(maybeEntity) !== entityRef) {
       continue;

--- a/plugins/scaffolder-yaml-actions/src/operations/set.test.ts
+++ b/plugins/scaffolder-yaml-actions/src/operations/set.test.ts
@@ -22,5 +22,28 @@ describe('set', () => {
       value: 'world!!!'
     })).toBe("hello: world!!!\n")
   });
+  it('allows to set value to resource entity', () => {
+    expect(set({
+      content: `metadata:
+  name: entity-a
+kind: component
+---
+metadata:
+      name: entity-b
+kind: resource
+`,
+      path: 'hello',
+      value: 'world!!!',
+      entityRef: 'resource:default/entity-b'
+    })).toBe(`metadata:
+  name: entity-a
+kind: component
+---
+metadata:
+  name: entity-b
+kind: resource
+hello: world!!!
+`)
+  });
 });
 

--- a/plugins/scaffolder-yaml-actions/src/operations/set.ts
+++ b/plugins/scaffolder-yaml-actions/src/operations/set.ts
@@ -21,7 +21,7 @@ export function set({
     const maybeEntity = document.contents.toJSON();
 
     if (typeof maybeEntity.kind === 'string' &&
-      typeof maybeEntity.name === 'string' &&
+      (typeof maybeEntity.name === 'string' || typeof maybeEntity.metadata?.name === 'string') &&
       entityRef &&
       stringifyEntityRef(maybeEntity) !== entityRef) {
       continue;


### PR DESCRIPTION
## Motivation

The YAML actions support an `entityRef` argument to update an specific entity from the content, but the current implementation doesn't take into account when the entity `name` is provided under `metadata`.

## Approach

Update the entity ref validation in the `append` and `set` operations to check for the `name` at root level and under `metadata` for each document.

### Alternate Designs

 <!-- OPTIONAL
   Explain what other alternatives you considered and why you chose this option.
 -->

### Possible Drawbacks or Risks

 <!-- OPTIONAL
   What are the possible side-effects or negative impacts of this change?
 -->

### TODOs and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the conclusion.
-->

## Learning

<!-- OPTIONAL
  Share any blog posts, patterns, libraries, or documentation that helped you.
-->

## Screenshots

<!-- OPTIONAL
  If relevant, include "before" and "after" to demonstrate this change. Add a caption describing what each screenshot shows.
-->
