### PR TITLE
Changed GraphQL plugins to bump to minor

### DIFF
--- a/.changeset/honest-suns-mate.md
+++ b/.changeset/honest-suns-mate.md
@@ -1,12 +1,12 @@
 ---
-'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+'@frontside/backstage-plugin-graphql-backend-module-catalog': minor
 '@frontside/backstage-plugin-incremental-ingestion-backend': patch
 '@frontside/backstage-plugin-incremental-ingestion-github': patch
-'@frontside/backstage-plugin-graphql-backend-node': patch
+'@frontside/backstage-plugin-graphql-backend-node': minor
 '@frontside/backstage-plugin-humanitec-backend': patch
-'@frontside/backstage-plugin-graphql-backend': patch
+'@frontside/backstage-plugin-graphql-backend': minor
 '@frontside/graphgen-backstage': patch
 'backend': patch
 ---
 
-Backport graphql plugins from Backstage PRFC #15519
+Backport graphql plugins from Backstage PRFC [#15519](https://github.com/backstage/backstage/pull/15519)

--- a/plugins/graphql-backend-module-catalog/package.json
+++ b/plugins/graphql-backend-module-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontside/backstage-plugin-graphql-backend-module-catalog",
-  "description": "An experimental module for the GraphQL backend that adds catalog schema",
+  "description": "Backstage GraphQL backend module that adds catalog schema",
   "version": "0.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/plugins/graphql-backend-node/package.json
+++ b/plugins/graphql-backend-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontside/backstage-plugin-graphql-backend-node",
-  "description": "An experimental Backstage backend extensions plugin for GraphQL",
+  "description": "Backstage backend extensions plugin for GraphQL",
   "version": "0.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/plugins/graphql-backend/package.json
+++ b/plugins/graphql-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontside/backstage-plugin-graphql-backend",
-  "description": "An experimental Backstage backend plugin for GraphQL",
+  "description": "Backstage backend plugin for GraphQL",
   "version": "0.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Motivation

Backstage GraphQL plugins were bumping to 0.0.1, but I wanted to do something more substantial like 0.1.0

## Approach

Change bumps to minor instead of patch and changed the descriptions to eliminate experimental.
