### PR TITLE
Update @frontside/hydraphql to 0.1.1

### DIFF
--- a/.changeset/friendly-yaks-rhyme.md
+++ b/.changeset/friendly-yaks-rhyme.md
@@ -1,0 +1,7 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+'@frontside/backstage-plugin-graphql-backend-node': patch
+'@frontside/backstage-plugin-graphql-backend': patch
+---
+
+Update @frontside/hydraphql to 0.1.1

--- a/plugins/graphql-backend-module-catalog/README.md
+++ b/plugins/graphql-backend-module-catalog/README.md
@@ -16,45 +16,50 @@ Some key features are currently missing. These features may change the schema in
 1. `viewer` query for retrieving data for the current user.
 
 - [GraphQL modules](#graphql-modules)
-  - [Catalog module](#catalog-module)
-  - [Relation module](#relation-module)
+  - [Backstage Plugins](#backstage-plugins)
+  - [Experimental Backend System](#experimental-backend-system)
 - [Directives API](#directives-api)
   - [`@relation` directive](#relation-directive)
 - [Catalog Data loader](#catalog-data-loader-advanced)
 
 ## GraphQL modules
 
-### Catalog module
+This package provides two GraphQL modules:
+- `Catalog` module – provides basic Catalog GraphQL types and `@relation` directive
+- `Relation` module – provides only `@relation` directive
 
-The `Catalog` module is installed just as any other Backstage Module:
-[`@frontside/backstage-plugin-graphql-backend`](../graphql-backend/README.md)
+### Backstage Plugins
 
+For the [Backstage plugin system](https://backstage.io/docs/plugins/backend-plugin),
+you can learn how to add GraphQL modules by checking out [GraphQL Modules](../graphql-backend/README.md#graphql-modules)
+section in `@frontside/backstage-plugin-graphql-backend` package.
+
+This package exports `Catalog` and `Relation` modules
+
+### Experimental Backend System
+
+For the [experimental backend system](https://backstage.io/docs/plugins/experimental-backend),
+you can add them as a plugin modules:
+
+- To use `Catalog` GraphQL module
 ```ts
 // packages/backend/src/index.ts
 import { graphqlModuleCatalog } from '@frontside/backstage-plugin-graphql-backend-module-catalog';
 
 const backend = createBackend();
-
-// GraphQL
-backend.use(graphqlPlugin());
 backend.use(graphqlModuleCatalog());
 ```
 
-### Relation module
-
-If you don't want to use basic Catalog types for some reason, but
-still want to use `@relation` directive, you can install `Relation` module
-
+- To use `Relation` GraphQL module
 ```ts
-// packages/backend/src/index.ts
 import { graphqlModuleRelationResolver } from '@frontside/backstage-plugin-graphql-backend-module-catalog';
 
 const backend = createBackend();
-
-// GraphQL
-backend.use(graphqlPlugin());
 backend.use(graphqlModuleRelationResolver());
 ```
+
+If you don't want to use basic Catalog types for some reason, but
+still want to use `@relation` directive, you can install `Relation` module
 
 ## Directives API
 

--- a/plugins/graphql-backend-module-catalog/package.json
+++ b/plugins/graphql-backend-module-catalog/package.json
@@ -46,7 +46,7 @@
     "@backstage/catalog-model": "^1.4.1",
     "@backstage/plugin-catalog-node": "^1.4.3",
     "@frontside/backstage-plugin-graphql-backend": "^0.1.0",
-    "@frontside/hydraphql": "^0.0.1",
+    "@frontside/hydraphql": "^0.1.1",
     "@graphql-tools/load-files": "^7.0.0",
     "@graphql-tools/utils": "^10.0.0",
     "dataloader": "^2.1.0",

--- a/plugins/graphql-backend-module-catalog/src/__snapshots__/codegen.test.ts.snap
+++ b/plugins/graphql-backend-module-catalog/src/__snapshots__/codegen.test.ts.snap
@@ -5,13 +5,13 @@ exports[`graphql-catalog codegen should generate the correct code: graphql 1`] =
 
 directive @discriminationAlias(type: String!, value: String!) repeatable on INTERFACE
 
-directive @field(at: _DirectiveArgument_!, default: _DirectiveArgument_) on FIELD_DEFINITION
+directive @field(at: _DirectiveArgument_, default: _DirectiveArgument_) on FIELD_DEFINITION
 
 directive @implements(interface: String!) on INTERFACE | OBJECT
 
 directive @relation(kind: String, name: String, nodeType: String) on FIELD_DEFINITION
 
-directive @resolve(at: _DirectiveArgument_, from: String) on FIELD_DEFINITION
+directive @resolve(at: _DirectiveArgument_, from: String, nodeType: String) on FIELD_DEFINITION
 
 interface API implements Entity & Node & Ownable {
   annotations: [KeyValuePair!]
@@ -2436,7 +2436,7 @@ export type DiscriminationAliasDirectiveArgs = {
 export type DiscriminationAliasDirectiveResolver<Result, Parent, ContextType = any, Args = DiscriminationAliasDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type FieldDirectiveArgs = {
-  at: Scalars['_DirectiveArgument_']['input'];
+  at?: Maybe<Scalars['_DirectiveArgument_']['input']>;
   default?: Maybe<Scalars['_DirectiveArgument_']['input']>;
 };
 
@@ -2459,6 +2459,7 @@ export type RelationDirectiveResolver<Result, Parent, ContextType = any, Args = 
 export type ResolveDirectiveArgs = {
   at?: Maybe<Scalars['_DirectiveArgument_']['input']>;
   from?: Maybe<Scalars['String']['input']>;
+  nodeType?: Maybe<Scalars['String']['input']>;
 };
 
 export type ResolveDirectiveResolver<Result, Parent, ContextType = any, Args = ResolveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;

--- a/plugins/graphql-backend-module-catalog/src/__testUtils__/createApi.ts
+++ b/plugins/graphql-backend-module-catalog/src/__testUtils__/createApi.ts
@@ -3,7 +3,6 @@ import type { JsonObject } from '@backstage/types';
 import {
   createGraphQLApp,
   GraphQLContext,
-  CoreSync,
 } from '@frontside/hydraphql';
 
 import * as graphql from 'graphql';
@@ -12,7 +11,7 @@ import { Module } from 'graphql-modules';
 import { envelop, useEngine } from '@envelop/core';
 import { useDataLoader } from '@envelop/dataloader';
 import { useGraphQLModules } from '@envelop/graphql-modules';
-import { RelationSync } from '../relation';
+import { Relation } from '../relation';
 
 export async function createGraphQLAPI(
   TestModule: Module,
@@ -20,7 +19,7 @@ export async function createGraphQLAPI(
   generateOpaqueTypes?: boolean,
 ) {
   const application = await createGraphQLApp({
-    modules: [CoreSync(), RelationSync(), TestModule],
+    modules: [Relation(), TestModule],
     generateOpaqueTypes,
   });
 

--- a/plugins/graphql-backend-module-catalog/src/catalog/catalog.ts
+++ b/plugins/graphql-backend-module-catalog/src/catalog/catalog.ts
@@ -1,12 +1,12 @@
-import { createModule, TypeDefs } from 'graphql-modules';
+import { createModule } from 'graphql-modules';
 import GraphQLJSON, { GraphQLJSONObject } from 'graphql-type-json';
 import { relationDirectiveMapper } from '../relationDirectiveMapper';
 import {
-  createDirectiveMapperProvider,
+  GraphQLModule,
   encodeId,
 } from '@frontside/hydraphql';
 import { stringifyEntityRef } from '@backstage/catalog-model';
-import { loadFiles, loadFilesSync } from '@graphql-tools/load-files';
+import { loadFilesSync } from '@graphql-tools/load-files';
 import { resolvePackagePath } from '@backstage/backend-common';
 import { CATALOG_SOURCE } from '../constants';
 
@@ -16,12 +16,11 @@ const catalogSchemaPath = resolvePackagePath(
 );
 
 /** @public */
-export const CatalogSync = (
-  typeDefs: TypeDefs = loadFilesSync(catalogSchemaPath),
-) =>
-  createModule({
+export const Catalog = (): GraphQLModule => ({
+  mappers: { relation: relationDirectiveMapper },
+  module: createModule({
     id: 'catalog',
-    typeDefs,
+    typeDefs: loadFilesSync(catalogSchemaPath),
     resolvers: {
       JSON: GraphQLJSON,
       JSONObject: GraphQLJSONObject,
@@ -55,11 +54,5 @@ export const CatalogSync = (
         }),
       },
     },
-    providers: [
-      createDirectiveMapperProvider('relation', relationDirectiveMapper),
-    ],
-  });
-
-/** @public */
-export const Catalog = async () =>
-  CatalogSync(await loadFiles(catalogSchemaPath));
+  })
+});

--- a/plugins/graphql-backend-module-catalog/src/relation/relation.ts
+++ b/plugins/graphql-backend-module-catalog/src/relation/relation.ts
@@ -1,7 +1,7 @@
-import { TypeDefs, createModule } from 'graphql-modules';
+import { createModule } from 'graphql-modules';
 import { relationDirectiveMapper } from '../relationDirectiveMapper';
-import { createDirectiveMapperProvider } from '@frontside/hydraphql';
-import { loadFiles, loadFilesSync } from '@graphql-tools/load-files';
+import { GraphQLModule } from '@frontside/hydraphql';
+import { loadFilesSync } from '@graphql-tools/load-files';
 import { resolvePackagePath } from '@backstage/backend-common';
 
 const relationSchemaPath = resolvePackagePath(
@@ -10,17 +10,10 @@ const relationSchemaPath = resolvePackagePath(
 );
 
 /** @public */
-export const RelationSync = (
-  typeDefs: TypeDefs = loadFilesSync(relationSchemaPath),
-) =>
-  createModule({
+export const Relation = (): GraphQLModule => ({
+  mappers: { relation: relationDirectiveMapper },
+  module: createModule({
     id: 'relation',
-    typeDefs,
-    providers: [
-      createDirectiveMapperProvider('relation', relationDirectiveMapper),
-    ],
-  });
-
-/** @public */
-export const Relation = async () =>
-  RelationSync(await loadFiles(relationSchemaPath));
+    typeDefs: loadFilesSync(relationSchemaPath),
+  })
+});

--- a/plugins/graphql-backend-module-catalog/src/relationDirectiveMapper.test.ts
+++ b/plugins/graphql-backend-module-catalog/src/relationDirectiveMapper.test.ts
@@ -1,5 +1,4 @@
 import {
-  CoreSync,
   transformSchema,
   encodeId,
   decodeId,
@@ -8,13 +7,12 @@ import DataLoader from 'dataloader';
 import { DocumentNode, GraphQLNamedType, printType } from 'graphql';
 import { createModule, gql } from 'graphql-modules';
 import { createGraphQLAPI } from './__testUtils__';
-import { RelationSync } from './relation/relation';
+import { Relation } from './relation/relation';
 
 describe('mapRelationDirective', () => {
   const transform = (source: DocumentNode) =>
     transformSchema([
-      CoreSync(),
-      RelationSync(),
+      Relation(),
       createModule({
         id: 'mapRelationDirective',
         typeDefs: source,

--- a/plugins/graphql-backend-module-catalog/src/schema.ts
+++ b/plugins/graphql-backend-module-catalog/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoreSync, transformSchema } from '@frontside/hydraphql';
+import { transformSchema } from '@frontside/hydraphql';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
-import { CatalogSync } from './catalog';
+import { Catalog } from './catalog';
 
 export const schema = printSchemaWithDirectives(
-  transformSchema([CoreSync(), CatalogSync()]),
+  transformSchema([Catalog()]),
 );

--- a/plugins/graphql-backend-node/package.json
+++ b/plugins/graphql-backend-node/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "^0.6.2",
-    "@frontside/hydraphql": "^0.0.1",
+    "@frontside/hydraphql": "^0.1.1",
     "dataloader": "^2.1.0",
     "graphql-modules": "^2.1.0",
     "graphql-yoga": "^4.0.3"

--- a/plugins/graphql-backend-node/src/extensions/graphqlModulesExtension.ts
+++ b/plugins/graphql-backend-node/src/extensions/graphqlModulesExtension.ts
@@ -1,10 +1,11 @@
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
+import { GraphQLModule } from '@frontside/hydraphql';
 import { Module } from 'graphql-modules';
 
 /** @public */
-export interface GraphQLModulesExtensionPoint {
+export interface GraphQLModulesExtensionPoint<T = Module | GraphQLModule> {
   addModules(
-    modules: ((() => Module | Promise<Module>) | Module | Promise<Module>)[],
+    modules: ((() => T | Promise<T>) | T | Promise<T>)[],
   ): void;
 }
 

--- a/plugins/graphql-backend/docs/backend-plugins.md
+++ b/plugins/graphql-backend/docs/backend-plugins.md
@@ -1,0 +1,197 @@
+# GraphQL Backend
+
+- [Getting started](#getting-started)
+- [GraphQL Modules](#graphql-modules)
+- [Envelop Plugins](#envelop-plugins)
+- [GraphQL Context](#graphql-context)
+- [Custom Data loaders](#custom-data-loaders-advanced)
+
+## Getting Started
+
+If you are using the [Backstage plugin system](https://backstage.io/docs/plugins/backend-plugin),
+then you can install the GraphQL Backend as a plugin
+
+1. Create a GraphQL plugin in your backend:
+
+```ts
+// packages/backend/src/plugins/graphql.ts
+import { createRouter } from '@frontside/backstage-plugin-graphql-backend';
+import { Router } from 'express';
+import { PluginEnvironment } from '../types';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    logger: env.logger,
+  });
+}
+```
+
+2. Add a route for the GraphQL plugin:
+
+```ts
+// packages/backend/src/index.ts
+import graphql from './plugins/graphql';
+
+// ...
+async function main() {
+  // ...
+  const graphqlEnv = useHotMemoize(module, () => createEnv('graphql'));
+  apiRouter.use('/graphql', await graphql(graphqlEnv));
+}
+```
+
+3. Start the backend
+
+```bash
+yarn workspace example-backend start
+```
+
+This will launch the full example backend. However, without any modules
+installed, you won't be able to do much with it.
+
+## GraphQL Modules
+
+The way to add new types and new resolvers to your GraphQL backend is
+with [GraphQL Modules][graphql-modules]. These are portable little
+bundles of schema that you can drop into place and have them extend
+your GraphQL server. The most important of these that is maintained by
+the Backstage team is the [graphql-backend-module-catalog][] module that makes your
+Catalog accessible via GraphQL. To add this module to your GraphQL server,
+add it to the `modules` array in your backend config:
+
+```ts
+import { createRouter } from '@frontside/backstage-plugin-graphql-backend';
+import { Catalog } from '@frontside/backstage-plugin-graphql-backend-module-catalog';
+
+// packages/backend/src/plugins/graphql.ts
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    logger: env.logger,
+    modules: [Catalog],
+  });
+}
+```
+
+To learn more about adding your own modules, see the [hydraphql][] package.
+
+## Envelop Plugins
+
+Whereas [Graphql Modules][graphql-modules] are used to extend the
+schema and resolvers of your GraphQL server, [Envelop][] plugins are
+used to extend its GraphQL stack with tracing, error handling, context
+extensions, and other middlewares.
+
+Plugins are be added via declaring GraphQL Yoga backend module.
+For example, to prevent potentially sensitive error messages from
+leaking to your client in production, add the [`useMaskedErrors`][usemaskederrors]
+plugin.
+
+```ts
+import { createRouter } from '@frontside/backstage-plugin-graphql-backend';
+import { useMaskedErrors } from '@envelop/core';
+
+// packages/backend/src/plugins/graphql.ts
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    logger: env.logger,
+    plugins: [useMaskedErrors()],
+  });
+}
+```
+
+## GraphQL Context
+
+The GraphQL context is an object that is passed to every resolver
+function. It is a convenient place to store data that is needed by
+multiple resolvers, such as a database connection or a logger.
+
+You can add additional data to the context to GraphQL Yoga backend module:
+
+```ts
+import { createRouter } from '@frontside/backstage-plugin-graphql-backend';
+
+// packages/backend/src/plugins/graphql.ts
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    logger: env.logger,
+    context: { myContext: 'Hello World' },
+  });
+}
+```
+
+## Custom Data Loaders (Advanced)
+
+By default, your graphql context will contain a `Dataloader` for retrieving
+records from the Catalog by their GraphQL ID. Most of the time this is all you
+will need. However, sometimes you will need to load data not just from the
+Backstage catalog, but from a different data source entirely. To do this, you
+will need to pass batch load functions for each data source.
+
+> ⚠️Caution! If you find yourself wanting to load data directly from a
+> source other than the catalog, first consider the idea of instead
+> just ingesting that data into the catalog, and then using the
+> default data loader. After consideration, If you still want to load
+> data directly from a source other than the Backstage catalog, then
+> proceed with care.
+
+Load functions are to GraphQL Yoga backend module. Each load function
+is stored under a unique key which is encoded inside node's id as a data
+source name
+
+```ts
+import { createRouter } from '@frontside/backstage-plugin-graphql-backend';
+import { NodeQuery } from '@frontside/hydraphql';
+
+// packages/backend/src/plugins/graphql.ts
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    logger: env.logger,
+    loaders: {
+      ProjectAPI: async (
+        queries: readonly NodeQuery[],
+        context: GraphQLContext,
+      ) => {
+        /* Fetch */
+      },
+      TaskAPI: async (queries: readonly NodeQuery[], context: GraphQLContext) => {
+        /* Fetch */
+      },
+    },
+  });
+}
+```
+
+Then you can use `@resolve` directive in your GraphQL schemas
+
+```graphql
+interface Node
+  @discriminates(with: "__source")
+  @discriminationAlias(value: "Project", type: "ProjectAPI")
+  @discriminationAlias(value: "Task", type: "TaskAPI")
+
+type Project @implements(interface "Node") {
+  tasks: [Task] @resolve(at: "spec.projectId", from: "TaskAPI")
+}
+
+type Task @implements(interface "Node") {
+  # ...
+}
+```
+
+[graphql]: https://graphql.org
+[envelop]: https://the-guild.dev/graphql/envelop
+[graphql-modules]: https://the-guild.dev/graphql/modules
+[graphql-catalog]: ../graphql-backend-module-catalog/README.md
+[hydraphql]: https://github.com/thefrontside/HydraphQL/blob/main/README.md
+[backstage-catalog]: https://backstage.io/docs/features/software-catalog/software-catalog-overview
+[usemaskederrors]: https://the-guild.dev/graphql/envelop/plugins/use-masked-errors

--- a/plugins/graphql-backend/package.json
+++ b/plugins/graphql-backend/package.json
@@ -39,7 +39,7 @@
     "@envelop/dataloader": "^5.0.0",
     "@envelop/graphql-modules": "^5.0.0",
     "@frontside/backstage-plugin-graphql-backend-node": "^0.1.0",
-    "@frontside/hydraphql": "^0.0.1",
+    "@frontside/hydraphql": "^0.1.1",
     "dataloader": "^2.1.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
@@ -55,6 +55,7 @@
     "supertest": "^6.1.3"
   },
   "files": [
-    "dist"
+    "dist",
+    "docs"
   ]
 }

--- a/plugins/graphql-backend/src/graphql.ts
+++ b/plugins/graphql-backend/src/graphql.ts
@@ -2,6 +2,7 @@ import { Module } from 'graphql-modules';
 import {
   GraphQLContext,
   BatchLoadFn,
+  GraphQLModule
 } from '@frontside/hydraphql';
 import { Plugin } from 'graphql-yoga';
 import { Options as DataLoaderOptions } from 'dataloader';
@@ -38,19 +39,20 @@ export const graphqlPlugin = createBackendPlugin({
       },
     });
 
-    const modules = new Map<string, Module>();
+    const modules = new Map<string, Module | GraphQLModule>();
     env.registerExtensionPoint(graphqlModulesExtensionPoint, {
       async addModules(newModules) {
         for (const module of newModules) {
           const resolvedModule = await (typeof module === 'function'
             ? module()
             : module);
-          if (modules.has(resolvedModule.id)) {
+          const moduleId = 'id' in resolvedModule ? resolvedModule.id : resolvedModule.module.id
+          if (modules.has(moduleId)) {
             throw new Error(
-              `A module with id "${resolvedModule.id}" has already been registered`,
+              `A module with id "${moduleId}" has already been registered`,
             );
           }
-          modules.set(resolvedModule.id, resolvedModule);
+          modules.set(moduleId, resolvedModule);
         }
       },
     });

--- a/plugins/graphql-backend/src/router.ts
+++ b/plugins/graphql-backend/src/router.ts
@@ -15,14 +15,14 @@ import {
   createGraphQLApp,
   GraphQLContext,
   BatchLoadFn,
-  Core,
+  GraphQLModule,
 } from '@frontside/hydraphql';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 export interface RouterOptions {
   appOptions?: GraphQLAppOptions;
   schemas?: string[];
-  modules?: Module[];
+  modules?: (Module| GraphQLModule)[];
   plugins?: Plugin[];
   loaders?: Record<string, BatchLoadFn<GraphQLContext>>;
   dataloaderOptions?: Options<string, any>;
@@ -49,7 +49,7 @@ export async function createRouter({
 
   let yoga: YogaServerInstance<any, any> | null = null;
   const application = await createGraphQLApp({
-    modules: [await Core(), ...modules],
+    modules,
     schema: [...schemas],
     ...appOptions,
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4584,10 +4584,10 @@
     graphql "16.5.0"
     hash.js "1.1.7"
 
-"@frontside/hydraphql@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@frontside/hydraphql/-/hydraphql-0.0.1.tgz#90cc11fbc8c8d19bff5e4f24fc29d8fc1040d608"
-  integrity sha512-VE/2yog1rVnkWBGcZHMtVaJGbKDLh71nDImc0SC0Z9TIqlw3yJds7ngfz8psX1qPz+IBqwxfRDaVM9aTWtLUeg==
+"@frontside/hydraphql@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@frontside/hydraphql/-/hydraphql-0.1.1.tgz#d903c426efe6c33d5d3682ff32eab4ebd801d5d1"
+  integrity sha512-giXQHJGor097xqAA9r3yqgu+T/DhCZ7SZSBSY+W670lHZxF5zPCL/+0SE3fK+qTiZV9MUU3nWHfbDs+MxT5pVw==
   dependencies:
     "@graphql-tools/code-file-loader" "^8.0.0"
     "@graphql-tools/graphql-file-loader" "^8.0.0"
@@ -4596,9 +4596,9 @@
     "@graphql-tools/merge" "^9.0.0"
     "@graphql-tools/schema" "^10.0.0"
     "@graphql-tools/utils" "^10.0.0"
+    graphql-relay "^0.10.0"
     lodash "^4.17.21"
     pascal-case "^3.1.2"
-    reflect-metadata "^0.1.13"
     tslib "^2.6.2"
 
 "@frontside/tsconfig@^1.2.0":
@@ -22614,11 +22614,6 @@ redux@^4.0.0, redux@^4.0.4, redux@^4.1.2:
   integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
   dependencies:
     "@babel/runtime" "^7.9.2"
-
-reflect-metadata@^0.1.13:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
-  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 reflect.getprototypeof@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
## Motivation

In HydraphQL 0.1 was changed a way how to declare directive mappers for graphql modules.

## Approach

- Updated graphql plugins according these changes
- Updated READMEs for graphql-backend and graphql-backend-module-catalog packages
