### PR TITLE
Add `encodeEntityId/decodeEntityId` helpers

### DIFF
--- a/.changeset/nasty-zebras-dress.md
+++ b/.changeset/nasty-zebras-dress.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+---
+
+Add `encodeEntityId/decodeEntityId` helpers

--- a/plugins/graphql-backend-module-catalog/src/catalogModule.ts
+++ b/plugins/graphql-backend-module-catalog/src/catalogModule.ts
@@ -1,6 +1,7 @@
 import { createBackendModule } from '@backstage/backend-plugin-api';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import {
+  graphqlContextExtensionPoint,
   graphqlLoadersExtensionPoint,
   graphqlModulesExtensionPoint,
 } from '@frontside/backstage-plugin-graphql-backend';
@@ -17,10 +18,12 @@ export const graphqlModuleCatalog = createBackendModule({
         catalog: catalogServiceRef,
         modules: graphqlModulesExtensionPoint,
         loaders: graphqlLoadersExtensionPoint,
+        context: graphqlContextExtensionPoint,
       },
-      async init({ catalog, modules, loaders }) {
+      async init({ catalog, modules, loaders, context }) {
         modules.addModules([Catalog]);
         loaders.addLoaders(createCatalogLoader(catalog));
+        context.setContext(ctx => ({ ...ctx, catalog }));
       },
     });
   },

--- a/plugins/graphql-backend-module-catalog/src/helpers.ts
+++ b/plugins/graphql-backend-module-catalog/src/helpers.ts
@@ -1,0 +1,18 @@
+import { CompoundEntityRef, Entity, parseEntityRef, stringifyEntityRef } from "@backstage/catalog-model";
+import { decodeId, encodeId } from "@frontside/hydraphql";
+import { CATALOG_SOURCE } from "./constants";
+
+export function encodeEntityId(entityOrRef: Entity | CompoundEntityRef | string): string {
+  const ref = typeof entityOrRef === 'string' ? entityOrRef : stringifyEntityRef(entityOrRef);
+  return encodeId({
+    source: CATALOG_SOURCE,
+    typename: 'Node',
+    query: { ref },
+  });
+}
+
+export function decodeEntityId(id: string): CompoundEntityRef {
+  const { query: { ref = '' } } = decodeId(id);
+
+  return parseEntityRef(ref);
+}

--- a/plugins/graphql-backend-module-catalog/src/index.ts
+++ b/plugins/graphql-backend-module-catalog/src/index.ts
@@ -1,3 +1,4 @@
+export * from './helpers';
 export * from './catalog';
 export * from './relation';
 export * from './catalogModule';

--- a/plugins/graphql-backend-module-catalog/src/relationModule.ts
+++ b/plugins/graphql-backend-module-catalog/src/relationModule.ts
@@ -1,6 +1,7 @@
 import { createBackendModule } from '@backstage/backend-plugin-api';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import {
+  graphqlContextExtensionPoint,
   graphqlLoadersExtensionPoint,
   graphqlModulesExtensionPoint,
 } from '@frontside/backstage-plugin-graphql-backend';
@@ -17,10 +18,12 @@ export const graphqlModuleRelationResolver = createBackendModule({
         catalog: catalogServiceRef,
         modules: graphqlModulesExtensionPoint,
         loaders: graphqlLoadersExtensionPoint,
+        context: graphqlContextExtensionPoint,
       },
-      async init({ catalog, modules, loaders }) {
+      async init({ catalog, modules, loaders, context }) {
         modules.addModules([Relation]);
         loaders.addLoaders(createCatalogLoader(catalog));
+        context.setContext(ctx => ({ ...ctx, catalog }));
       },
     });
   },

--- a/plugins/graphql-backend/README.md
+++ b/plugins/graphql-backend/README.md
@@ -12,7 +12,7 @@ At a minimum, you should install the [graphql-backend-module-catalog][] which ad
 schema elements to access the [Backstage Catalog][backstage-catalog] via GraphQL
 
 - [Backstage Plugins](./docs/backend-plugins.md#getting-started)
-- [Experimental Backend System](#experimental-backend-system)
+- [Backend System](#backend-system)
   - [Getting started](#getting-started)
   - [GraphQL Modules](#graphql-modules)
     - [Custom GraphQL Module](#custom-graphql-module)
@@ -25,7 +25,7 @@ schema elements to access the [Backstage Catalog][backstage-catalog] via GraphQL
   - [Backstage API Docs](#backstage-api-docs)
 - [Questions](#questions)
 
-## Experimental Backend System
+## Backend System
 
 This approach is suitable for the new [Backstage backend system](https://backstage.io/docs/backend-system/).
 For the current [Backstage plugins system](https://backstage.io/docs/plugins/backend-plugin) see [Backstage Plugins](./docs/backend-plugins.md#getting-started)


### PR DESCRIPTION
## Motivation

Sometimes users might write custom resolvers for graphql-plugin, for example they want to query backstage catalog first and then pass received entities further in a graphql query, so entities must be transformed to graphql NodeIds. It's possible to use `encodeId` from `hydraphql` for that, but it's a little overwhelming and not intuitive, because it requires some internal context of `NodeId` type structure.   

## Approach

Simplify encoding NodeIds and provide function that took `Entity` or `EntityRef` as an input and return encoded NodeId string back.
