### PR TITLE
Allow target files to be in directories

### DIFF
--- a/.changeset/soft-gifts-chew.md
+++ b/.changeset/soft-gifts-chew.md
@@ -1,0 +1,5 @@
+---
+'@frontside/scaffolder-yaml-actions': patch
+---
+
+Allow target files to be in directories

--- a/plugins/scaffolder-yaml-actions/src/actions/append.ts
+++ b/plugins/scaffolder-yaml-actions/src/actions/append.ts
@@ -63,6 +63,7 @@ export function createYamlAppendAction({
           ...ctx,
           input: {
             url: _path.dirname(ctx.input.url),
+            targetPath: _path.dirname(filepath)
           },
         });
         

--- a/plugins/scaffolder-yaml-actions/src/actions/set.ts
+++ b/plugins/scaffolder-yaml-actions/src/actions/set.ts
@@ -63,6 +63,7 @@ export function createYamlSetAction({
           ...ctx,
           input: {
             url: _path.dirname(ctx.input.url),
+            targetPath: _path.dirname(filepath)
           },
         });
 


### PR DESCRIPTION
## Motivation

It was reported to us that `yaml:set` action wasn't working when file was in a directory.

## Approach

Pass targetPath to fetch plain action
