### PR TITLE
Pass `formContext` through scaffolder `FormProps`

### DIFF
--- a/.changeset/big-chefs-provide.md
+++ b/.changeset/big-chefs-provide.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-scaffolder-workflow': minor
+---
+
+Allow passing formContext through the FormProps to scaffolder form.

--- a/plugins/scaffolder-frontend-workflow/src/components/Form/Form.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/Form/Form.tsx
@@ -62,7 +62,7 @@ export const Form = ({
       uiSchema={step.uiSchema}
       fields={fields}
       formData={formData}
-      formContext={{ formData }}
+      formContext={{ ...props.formContext, formData }}
       onSubmit={onSubmit}
       onChange={handleChange}
       {...props}

--- a/plugins/scaffolder-frontend-workflow/src/components/Form/RJSFForm.tsx
+++ b/plugins/scaffolder-frontend-workflow/src/components/Form/RJSFForm.tsx
@@ -4,5 +4,5 @@ export const RJSFForm = withTheme(require('@rjsf/material-ui').Theme);
 
 export type RJSFFormProps = Pick<
   FormProps,
-  'transformErrors' | 'extraErrors' | 'className' | 'ref'
+  'transformErrors' | 'extraErrors' | 'formContext' | 'className' | 'ref'
 >;


### PR DESCRIPTION
## Motivation

This allows the user to add additional `formContext` when constructing the form. This value is passed to the form and each form component.

## Approach

Bit of prop drilling.
