### PR TITLE
Resolve node to null if entity doesn't exist

### DIFF
--- a/.changeset/dry-news-share.md
+++ b/.changeset/dry-news-share.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+---
+
+Resolve node to null if entity doesn't exist


### PR DESCRIPTION
## Motivation

Currently, the resolver generated by relation directive mapper doesn't check existence of entities and just returns node ids of them. This cause an error when GraphQL tries to resolve non-null field, but fails, because there is no entity returned for that id.

## Approach

Added simple check to existence of entities. Because in most cases user queries additional fields of node we load an entity anyway, so it should have negative effect on performance.
