### PR TITLE
fix(humanitec): failing connections with authenticated api requests

### DIFF
--- a/.changeset/blue-donuts-refuse.md
+++ b/.changeset/blue-donuts-refuse.md
@@ -1,0 +1,7 @@
+---
+'@frontside/backstage-plugin-humanitec-backend': patch
+'@frontside/backstage-plugin-humanitec-common': patch
+'@frontside/backstage-plugin-humanitec': patch
+---
+
+Fixed connection when using authenticated API requests

--- a/plugins/humanitec-backend/src/service/router.ts
+++ b/plugins/humanitec-backend/src/service/router.ts
@@ -58,13 +58,14 @@ export async function createRouter(
 
     const client = createHumanitecClient({ token, orgId });
 
+    let id = 0;
     let timeout: NodeJS.Timeout;
 
     function scheduleUpdate(interval: number) {
       async function update() {
         const result = await fetchAppInfo({ client }, appId);
         const data = JSON.stringify(result);
-        response.write(`event: update-success\ndata: ${data}\n\n`);
+        response.write(`event: update-success\ndata: ${data}\nid: ${id++}\n\n`);
         flush(response);
       }
 
@@ -73,10 +74,9 @@ export async function createRouter(
           timeout = setTimeout(() => scheduleUpdate(interval), interval);
         })
         .catch((e) => {
-          response.write(`event: update-failure\ndata: ${e.message}\n\n`);
+          response.write(`event: update-failure\ndata: ${e.message}\nid: ${id++}\n\n`);
           flush(response);
-          logger.error(`Error encountered trying to update environment`);
-          logger.debug(e);
+          logger.error(`Error encountered trying to update environment`, e);
           response.end();
         })
     }

--- a/plugins/humanitec-common/src/types/deployment.ts
+++ b/plugins/humanitec-common/src/types/deployment.ts
@@ -4,7 +4,7 @@ export const Deployment = object({
   comment: string(),
   created_at: string(),
   created_by: string(),
-  delta_id: string(),
+  delta_id: string().optional(),
   env_id: string(),
   export_file: string(),
   export_status: string(),

--- a/plugins/humanitec/package.json
+++ b/plugins/humanitec/package.json
@@ -31,6 +31,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "@types/lodash.get": "^4.4.7",
+    "event-source-polyfill": "^1.0.31",
     "lodash.get": "^4.4.2",
     "react-use": "^17.2.4"
   },


### PR DESCRIPTION
## Motivation

<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

The Humanitec Plugin doesn't include the `Authentication` header when enabling authenticated API requests https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md

## Approach

Include the token as header for event requests. Sadly the default EventSource doesn't support headers, hence we need to switch to https://github.com/Yaffle/EventSource.

A similar approach was taken in backstage core https://github.com/backstage/backstage/blob/86baccb2d7d378baed74eaebf017c60b410986e5/plugins/scaffolder/src/api.ts#L248-L253
