### PR TITLE
fix(humanitec): deduplicate updates for the same orgId/appId

### DIFF
--- a/.changeset/spotty-ears-cheer.md
+++ b/.changeset/spotty-ears-cheer.md
@@ -1,0 +1,7 @@
+---
+'@frontside/backstage-plugin-humanitec-backend': patch
+'@frontside/backstage-plugin-humanitec-common': patch
+'@frontside/backstage-plugin-humanitec': patch
+---
+
+Deduplicate updates for the same orgId/appId

--- a/plugins/humanitec-backend/src/service/app-info-service.ts
+++ b/plugins/humanitec-backend/src/service/app-info-service.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'events';
+
+import { createHumanitecClient, fetchAppInfo } from '@frontside/backstage-plugin-humanitec-common';
+
+const fetchInterval = 10000;
+
+export interface AppInfoUpdate {
+    id: number;
+    data?: any;
+    error?: Error;
+}
+
+// This service is responsible for fetching app info from Humanitec on an interval and updating all subscribers.
+//
+// Subscribers aren't fetching app info directly because we want to avoid multiple requests for the same app info.
+//
+export class AppInfoService {
+    private emitter: EventEmitter = new EventEmitter();
+    private pending: Record<string, Promise<any>> = {};
+    private timeouts: Record<string, NodeJS.Timeout> = {};
+    private lastData: Record<string, AppInfoUpdate> = {};
+
+    private token: string;
+
+    constructor(token: string) {
+        this.token = token;
+    }
+
+    addSubscriber(orgId: string, appId: string, subscriber: (data: AppInfoUpdate) => void): () => void {
+        const key = `${orgId}:${appId}`;
+
+        this.emitter.on(key, subscriber);
+
+        // Only fetch app info if a fetch is not pending.
+        if (!this.pending[key]) {
+            this.fetchAppInfo(orgId, appId);
+        } else {
+            if (this.lastData[key]) {
+                subscriber(this.lastData[key]);
+            }
+        }
+
+        // Return a function that removes this subscriber when it's no longer interested.
+        return () => {
+            this.emitter.off(key, subscriber);
+            if (this.emitter.listenerCount(key) === 0 && this.timeouts[key]) {
+                clearTimeout(this.timeouts[key]);
+                delete this.pending[key];
+                delete this.timeouts[key];
+                delete this.lastData[key];
+            }
+        };
+    }
+
+    private fetchAppInfo(orgId: string, appId: string): Promise<any> {
+        const key = `${orgId}:${appId}`;
+        const client = createHumanitecClient({ token: this.token, orgId });
+        let id = 0;
+
+        this.pending[key] = (async () => {
+            const update: AppInfoUpdate = { id: id++ };
+            try {
+                const data = await fetchAppInfo({ client }, appId);
+                update.data = data;
+
+                this.timeouts[key] = setTimeout(()=> this.fetchAppInfo(orgId, appId), fetchInterval);
+            } catch (error) {
+                if (error instanceof Error) {
+                    update.error = error;
+                } else {
+                    update.error = new Error(`${error}`);
+                }
+            } finally {
+                this.emitter.emit(key, update);
+                this.lastData[key] = update;
+            }
+        })();
+        return this.pending[key];
+    }
+}

--- a/plugins/humanitec/package.json
+++ b/plugins/humanitec/package.json
@@ -47,6 +47,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.5.1",
+    "@types/event-source-polyfill": "^1.0.5",
     "@types/jest": "*",
     "@types/node": "*",
     "cross-fetch": "^3.1.5",

--- a/plugins/humanitec/src/hooks/useAppInfo.ts
+++ b/plugins/humanitec/src/hooks/useAppInfo.ts
@@ -17,17 +17,21 @@ export function useAppInfo({ appId, orgId }: { appId: string; orgId: string }) {
       createEventSource().then((s) => {
         source = s;
 
-        source.addEventListener('update-success', (message) => {
+        source.addEventListener('update-success', (message: any) => {
           try {
-            setData(JSON.parse(message.data));
+            if (message.data) {
+              setData(JSON.parse(message.data));
+            }
           } catch (e) {
             // eslint-disable-next-line no-console
             console.error(e);
           }
         });
 
-        source.addEventListener('update-failure', (message) => {
-          setData(new Error(message.data))
+        source.addEventListener('update-failure', (message: any) => {
+          if (message.data) {
+            setData(new Error(message.data));
+          }
           source.close();
         });
       }, (e) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9540,6 +9540,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/event-source-polyfill@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz#7223387b99ff519b0fed6278961c84315ffc14b7"
+  integrity sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==
+
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.33", "@types/express-serve-static-core@^4.17.5":
   version "4.17.36"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz#baa9022119bdc05a4adfe740ffc97b5f9360e545"


### PR DESCRIPTION
## Motivation

<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

People often open multiple tabs of backstage and there is no point in requesting the same information multiple times.

## Approach

<!-- REQUIRED
  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
-->

Keep the latest update in-memory and ensure only one update loop is running that dispatches to all open subscriptions.