### PR TITLE
Pass auth token to catalogClient on queries

### DIFF
--- a/packages/backend/src/plugins/graphql.ts
+++ b/packages/backend/src/plugins/graphql.ts
@@ -10,6 +10,6 @@ export default async function createPlugin(
   return await createRouter({
     logger: env.logger,
     modules: [myModule, Catalog()],
-    loaders: { ...createCatalogLoader(env.catalog) },
+    loaders: { ...createCatalogLoader(env.catalog, env.tokenManager) },
   });
 }

--- a/plugins/graphql-backend-module-catalog/src/catalogModule.ts
+++ b/plugins/graphql-backend-module-catalog/src/catalogModule.ts
@@ -1,4 +1,4 @@
-import { createBackendModule } from '@backstage/backend-plugin-api';
+import { createBackendModule, coreServices } from '@backstage/backend-plugin-api';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import {
   graphqlContextExtensionPoint,
@@ -19,10 +19,11 @@ export const graphqlModuleCatalog = createBackendModule({
         modules: graphqlModulesExtensionPoint,
         loaders: graphqlLoadersExtensionPoint,
         context: graphqlContextExtensionPoint,
+        tokenManager: coreServices.tokenManager,
       },
-      async init({ catalog, modules, loaders, context }) {
+      async init({ catalog, modules, loaders, context, tokenManager }) {
         modules.addModules([Catalog]);
-        loaders.addLoaders(createCatalogLoader(catalog));
+        loaders.addLoaders(createCatalogLoader(catalog, tokenManager));
         context.setContext(ctx => ({ ...ctx, catalog }));
       },
     });

--- a/plugins/graphql-backend-module-catalog/src/entitiesLoadFn.ts
+++ b/plugins/graphql-backend-module-catalog/src/entitiesLoadFn.ts
@@ -3,8 +3,10 @@ import { Entity } from '@backstage/catalog-model';
 import { NodeQuery } from '@frontside/hydraphql';
 import { GraphQLError } from 'graphql';
 import { CATALOG_SOURCE } from './constants';
+import { TokenManagerService } from '@backstage/backend-plugin-api';
 
-export const createCatalogLoader = (catalog: CatalogApi) => ({
+
+export const createCatalogLoader = (catalog: CatalogApi, tokenManager: TokenManagerService) => ({
   [CATALOG_SOURCE]: async (
     queries: readonly (NodeQuery | undefined)[],
   ): Promise<Array<Entity | GraphQLError>> => {
@@ -14,9 +16,10 @@ export const createCatalogLoader = (catalog: CatalogApi) => ({
       new Map<number, string>(),
     );
     const refEntries = [...entityRefs.entries()];
+    const { token } = await tokenManager.getToken();
     const result = await catalog.getEntitiesByRefs({
       entityRefs: refEntries.map(([, ref]) => ref),
-    });
+    },  { token });
     const entities: (Entity | GraphQLError)[] = Array.from({
       length: queries.length,
     });

--- a/plugins/graphql-backend-module-catalog/src/relationModule.ts
+++ b/plugins/graphql-backend-module-catalog/src/relationModule.ts
@@ -1,4 +1,4 @@
-import { createBackendModule } from '@backstage/backend-plugin-api';
+import { createBackendModule, coreServices } from '@backstage/backend-plugin-api';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import {
   graphqlContextExtensionPoint,
@@ -19,10 +19,11 @@ export const graphqlModuleRelationResolver = createBackendModule({
         modules: graphqlModulesExtensionPoint,
         loaders: graphqlLoadersExtensionPoint,
         context: graphqlContextExtensionPoint,
+        tokenManager: coreServices.tokenManager,
       },
-      async init({ catalog, modules, loaders, context }) {
+      async init({ catalog, modules, loaders, context, tokenManager }) {
         modules.addModules([Relation]);
-        loaders.addLoaders(createCatalogLoader(catalog));
+        loaders.addLoaders(createCatalogLoader(catalog, tokenManager));
         context.setContext(ctx => ({ ...ctx, catalog }));
       },
     });


### PR DESCRIPTION
## Motivation

When authz is enabled a token is required to query the catalog.

## Approach

Here we use the tokenManager and call the catalog as a service-to-service call.

### Alternate Designs

Ideally we'd pass the user's token directly but I'm not sure how to get their identity token from this code.
There are two different `IdentityApi`s -- the one in `@backstage/core-plugin-api` which provides the necessary `.getCredentials()` method that would give us the user's token, however when wiring the `catalogModule` it seems we need a `ServiceRef`. The `coreServices.identity` service is a different `IdentityApi` from `@backstage/plugin-auth-node` which implements a validation function to validate a given token, but not retrieve one from the request.

### Possible Drawbacks or Risks

Using a service-to-service token we are bypassing permissions policies that may be applied to the user for the catalog api.

### TODOs and Open Questions

- [ ] Confirm if we can get the user's token instead for making these catalog api calls.

## Learning


## Screenshots
