### PR TITLE
Pass Backstage auth token to catalog.getEntitiesByRefs

### DIFF
--- a/.changeset/fuzzy-ghosts-applaud.md
+++ b/.changeset/fuzzy-ghosts-applaud.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+---
+
+Pass Backstage auth token to Catalog client requests

--- a/plugins/graphql-backend-module-catalog/package.json
+++ b/plugins/graphql-backend-module-catalog/package.json
@@ -44,6 +44,7 @@
     "@backstage/backend-plugin-api": "^0.6.7",
     "@backstage/catalog-client": "^1.4.6",
     "@backstage/catalog-model": "^1.4.3",
+    "@backstage/plugin-auth-node": "^0.4.1",
     "@backstage/plugin-catalog-node": "^1.5.0",
     "@frontside/backstage-plugin-graphql-backend": "^0.1.4",
     "@frontside/hydraphql": "^0.1.1",

--- a/plugins/graphql-backend-module-catalog/src/entitiesLoadFn.ts
+++ b/plugins/graphql-backend-module-catalog/src/entitiesLoadFn.ts
@@ -1,14 +1,19 @@
 import type { CatalogApi } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
-import { NodeQuery } from '@frontside/hydraphql';
+import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
+import { GraphQLContext, NodeQuery } from '@frontside/hydraphql';
 import { GraphQLError } from 'graphql';
+import type { Request } from 'express';
 import { CATALOG_SOURCE } from './constants';
 
 export const createCatalogLoader = (catalog: CatalogApi) => ({
   [CATALOG_SOURCE]: async (
     queries: readonly (NodeQuery | undefined)[],
+    context: GraphQLContext & { request?: Request }
   ): Promise<Array<Entity | GraphQLError>> => {
     // TODO: Support fields
+    const request = context.request;
+    const token = request ? getBearerTokenFromAuthorizationHeader(request.headers.authorization) : undefined;
     const entityRefs = queries.reduce(
       (refs, { ref } = {}, index) => (ref ? refs.set(index, ref) : refs),
       new Map<number, string>(),
@@ -16,7 +21,7 @@ export const createCatalogLoader = (catalog: CatalogApi) => ({
     const refEntries = [...entityRefs.entries()];
     const result = await catalog.getEntitiesByRefs({
       entityRefs: refEntries.map(([, ref]) => ref),
-    });
+    }, { token });
     const entities: (Entity | GraphQLError)[] = Array.from({
       length: queries.length,
     });


### PR DESCRIPTION
## Motivation

@kunickiaj has issue with Catalog GraphQL Plugin while using Backstage Catalog with authz enabled. Because Catalog data loader requests entities from catalog without token, which leads to 401 HTTP Error and GraphQL query fails

## Approach

Yoga GraphQL Server, which we are using passes HTTP Request to GraphQL Context. It allows us to grab auth token from request headers, that is put there by Backstage https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md