### PR TITLE
Use correct request type for extracting auth token

### DIFF
--- a/.changeset/little-horses-end.md
+++ b/.changeset/little-horses-end.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+---
+
+Corrects the request type used for extracting auth token for catalog requests.

--- a/plugins/graphql-backend-module-catalog/src/entitiesLoadFn.ts
+++ b/plugins/graphql-backend-module-catalog/src/entitiesLoadFn.ts
@@ -3,7 +3,7 @@ import { Entity } from '@backstage/catalog-model';
 import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
 import { GraphQLContext, NodeQuery } from '@frontside/hydraphql';
 import { GraphQLError } from 'graphql';
-import type { Request } from 'express';
+import type { Request } from 'node-fetch';
 import { CATALOG_SOURCE } from './constants';
 
 export const createCatalogLoader = (catalog: CatalogApi) => ({
@@ -13,7 +13,7 @@ export const createCatalogLoader = (catalog: CatalogApi) => ({
   ): Promise<Array<Entity | GraphQLError>> => {
     // TODO: Support fields
     const request = context.request;
-    const token = request ? getBearerTokenFromAuthorizationHeader(request.headers.authorization) : undefined;
+    const token = getBearerTokenFromAuthorizationHeader(request?.headers.get('authorization'));
     const entityRefs = queries.reduce(
       (refs, { ref } = {}, index) => (ref ? refs.set(index, ref) : refs),
       new Map<number, string>(),


### PR DESCRIPTION
## Motivation

The request type from express does not match the data received. The data received is in the format of a node-fetch Request. Using the correct data structure allows the request headers to be parsed correctly for extracting the authz token.

## Approach

Corrects the type to Request from `node-fetch`.