### PR TITLE
fix(humanitec): continue polling on error

### DIFF
--- a/.changeset/green-coats-march.md
+++ b/.changeset/green-coats-march.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-humanitec-backend': patch
+---
+
+Continue polling when an error is returned.

--- a/plugins/humanitec-backend/src/service/app-info-service.test.ts
+++ b/plugins/humanitec-backend/src/service/app-info-service.test.ts
@@ -1,0 +1,126 @@
+import { setTimeout } from 'node:timers/promises';
+import * as common from '@frontside/backstage-plugin-humanitec-common';
+
+import { AppInfoService } from './app-info-service';
+
+const fetchInterval = 50;
+
+let returnError = false;
+const fakeAppInfo = { fake: 'res' }
+const fakeError = new Error('fake error');
+
+jest.mock('@frontside/backstage-plugin-humanitec-common', () => ({
+  createHumanitecClient: jest.fn(),
+  fetchAppInfo: jest.fn(async () => {
+    if (returnError) {
+      throw fakeError;
+    }
+
+    return fakeAppInfo;
+  }),
+}))
+
+describe('AppInfoService', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    returnError = false;
+  });
+
+  it('single subscriber', async () => {
+    const service = new AppInfoService('token', fetchInterval);
+    const subscriber = jest.fn();
+
+    const close = service.addSubscriber('orgId', 'appId', subscriber);
+
+    await setTimeout(50);
+
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(subscriber).toHaveBeenLastCalledWith({ id: 0, data: fakeAppInfo });
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(1);
+
+    await setTimeout(fetchInterval);
+
+    expect(subscriber).toHaveBeenCalledTimes(2);
+    expect(subscriber).toHaveBeenLastCalledWith({ id: 1, data: fakeAppInfo });
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(2);
+
+    close();
+
+    await setTimeout(fetchInterval * 2);
+
+    expect(subscriber).toHaveBeenCalledTimes(2);
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('single subscriber, recovers after an erro', async () => {
+    returnError = true
+
+    const service = new AppInfoService('token', fetchInterval);
+    const subscriber = jest.fn();
+
+    const close = service.addSubscriber('orgId', 'appId', subscriber);
+
+    await setTimeout(50);
+
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(subscriber).toHaveBeenLastCalledWith({ id: 0, error: fakeError });
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(1);
+
+    returnError = false;
+
+    await setTimeout(fetchInterval);
+
+    expect(subscriber).toHaveBeenCalledTimes(2);
+    expect(subscriber).toHaveBeenLastCalledWith({ id: 1, data: fakeAppInfo });
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(2);
+
+    close();
+
+    await setTimeout(fetchInterval * 2);
+
+    expect(subscriber).toHaveBeenCalledTimes(2);
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('two subscribers', async () => {
+    const service = new AppInfoService('token', fetchInterval);
+    const subscriber1 = jest.fn();
+    const subscriber2 = jest.fn();
+
+    const close1 = service.addSubscriber('orgId', 'appId', subscriber1);
+    const close2 = service.addSubscriber('orgId', 'appId', subscriber2);
+
+    await setTimeout(10);
+
+    expect(subscriber1).toHaveBeenCalledTimes(1);
+    expect(subscriber2).toHaveBeenCalledTimes(1);
+    expect(subscriber1).toHaveBeenLastCalledWith({ id: 0, data: fakeAppInfo });
+    expect(subscriber2).toHaveBeenLastCalledWith({ id: 0, data: fakeAppInfo });
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(1);
+
+    await setTimeout(fetchInterval);
+
+    expect(subscriber1).toHaveBeenCalledTimes(2);
+    expect(subscriber1).toHaveBeenLastCalledWith({ id: 1, data: fakeAppInfo });
+    expect(subscriber2).toHaveBeenCalledTimes(2);
+    expect(subscriber2).toHaveBeenLastCalledWith({ id: 1, data: fakeAppInfo });
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(2);
+
+    close1();
+
+    await setTimeout(fetchInterval);
+
+    expect(subscriber1).toHaveBeenCalledTimes(2);
+    expect(subscriber2).toHaveBeenCalledTimes(3);
+    expect(subscriber2).toHaveBeenLastCalledWith({ id: 2, data: fakeAppInfo });
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(3);
+
+    close2();
+
+    await setTimeout(fetchInterval);
+
+    expect(subscriber1).toHaveBeenCalledTimes(2);
+    expect(subscriber2).toHaveBeenCalledTimes(3);
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(3);
+  });
+});

--- a/plugins/humanitec-backend/src/service/router.ts
+++ b/plugins/humanitec-backend/src/service/router.ts
@@ -61,15 +61,11 @@ export async function createRouter(
     const unsubscribe = appInfoService.addSubscriber(orgId, appId, (data) => {
       if (data.error) {
         response.write(`event: update-failure\ndata: ${data.error.message}\nid: ${data.id}\n\n`);
-        flush(response);
         logger.error(`Error encountered trying to update environment`, data.error);
-        response.end();
-        unsubscribe();
-
-        return
+      } else {
+        response.write(`event: update-success\ndata: ${JSON.stringify(data.data)}\nid: ${data.id}\n\n`);
       }
 
-      response.write(`event: update-success\ndata: ${JSON.stringify(data.data)}\nid: ${data.id}\n\n`);
       flush(response);
     });
 


### PR DESCRIPTION
## Motivation

<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

Continue polling when an error is returned instead ending the request, which didn't really made sense as the event socket is directly opened again by the Backstage client.

Additionally use Maps here and add a couple of tests for the dispatching logic.
