### PR TITLE
Correct import of graphql-backend-node package

### DIFF
--- a/plugins/graphql-backend/README.md
+++ b/plugins/graphql-backend/README.md
@@ -122,7 +122,7 @@ export const myModule = createModule({
 ```ts
 // packages/backend/src/modules/graphqlMyModule.ts
 import { createBackendModule } from "@backstage/backend-plugin-api";
-import { graphqlModulesExtensionPoint } from "@backstage/plugin-graphql-backend-node";
+import { graphqlModulesExtensionPoint } from "@frontside/backstage-plugin-graphql-backend-node";
 import { MyModule } from "../modules/my-module/my-module";
 
 export const graphqlModuleMyModule = createBackendModule({


### PR DESCRIPTION
It's using old backstage packages instead of frontside package

