### PR TITLE
Upgraded graphql-modules to 2.3.0

### DIFF
--- a/.changeset/clean-pugs-develop.md
+++ b/.changeset/clean-pugs-develop.md
@@ -1,0 +1,8 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+'@frontside/backstage-plugin-graphql-backend-node': patch
+'@frontside/backstage-plugin-graphql-backend': patch
+'backend': patch
+---
+
+Upgraded to graphql-modules 2.3.0

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -60,7 +60,7 @@
     "express-promise-router": "^4.1.0",
     "fs-extra": "^11.1.0",
     "git-url-parse": "^13.1.0",
-    "graphql-modules": "^2.1.0",
+    "graphql-modules": "^2.3.0",
     "js-yaml": "^4.1.0",
     "luxon": "^2.3.1",
     "octokit": "^2.0.9",

--- a/plugins/graphql-backend-module-catalog/package.json
+++ b/plugins/graphql-backend-module-catalog/package.json
@@ -51,7 +51,7 @@
     "@graphql-tools/utils": "^10.0.0",
     "dataloader": "^2.1.0",
     "graphql": "^16.6.0",
-    "graphql-modules": "^2.1.0",
+    "graphql-modules": "^2.3.0",
     "graphql-relay": "^0.10.0",
     "graphql-type-json": "^0.3.2"
   },

--- a/plugins/graphql-backend-node/package.json
+++ b/plugins/graphql-backend-node/package.json
@@ -36,7 +36,7 @@
     "@backstage/backend-plugin-api": "^0.6.7",
     "@frontside/hydraphql": "^0.1.1",
     "dataloader": "^2.1.0",
-    "graphql-modules": "^2.1.0",
+    "graphql-modules": "^2.3.0",
     "graphql-yoga": "^4.0.3"
   },
   "devDependencies": {

--- a/plugins/graphql-backend/package.json
+++ b/plugins/graphql-backend/package.json
@@ -44,7 +44,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "graphql": "^16.6.0",
-    "graphql-modules": "^2.1.0",
+    "graphql-modules": "^2.3.0",
     "graphql-yoga": "^4.0.3",
     "helmet": "^6.0.0",
     "winston": "^3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16219,10 +16219,10 @@ graphql-language-service@5.2.0, graphql-language-service@^5.2.0:
     nullthrows "^1.0.0"
     vscode-languageserver-types "^3.17.1"
 
-graphql-modules@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/graphql-modules/-/graphql-modules-2.2.0.tgz#c857798240a1c7cea7c57ac85e07a765151ee369"
-  integrity sha512-iWFyqP+jZqlwPkM4zVI0A/GDgQErxCTZeiz/jVv0MNzKut+ZEV6Dx8TlLhHd6VLqrqHZmib4NybG5Me8E03jDg==
+graphql-modules@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/graphql-modules/-/graphql-modules-2.3.0.tgz#6b0c4ea97838a64c1900e61e28ec571cb0922d12"
+  integrity sha512-CcrjUjMYHy3zelnffldhR3h6t4ndCVJEzdqBAv/mp4ZGEA/izirOKZB2lnRwpXNqOtVwIz2O/E1Cg/UH8dFNaQ==
   dependencies:
     "@graphql-tools/schema" "^10.0.0"
     "@graphql-tools/wrap" "^10.0.0"


### PR DESCRIPTION
## Motivation

[adam in discord](https://discord.com/channels/687207715902193673/1199430386560815226/1204210331023573022) mentioned that he had to specify resolutions to get graphql-modules to work because 2.1.0 and 2.3.0 are incompatible. 

## Approach

Bump graphql-modules to 2.3.0

## TODO

- [ ] Upgrade HydraphQL after https://github.com/thefrontside/HydraphQL/pull/16 is merged
