### PR TITLE
Added default exports to graphql modules

### DIFF
--- a/.changeset/slimy-cooks-relate.md
+++ b/.changeset/slimy-cooks-relate.md
@@ -7,18 +7,18 @@ Make module default exports to allow using import syntax
 
 This change allows to use import syntax to load modules
 
-```ts
+```diff
 import { createBackend } from '@backstage/backend-defaults';
-- import { graphqlPlugin } from '@frontside/backstage-plugin-graphql-backend';
-- import { graphqlModuleCatalog } from '@frontside/backstage-plugin-graphql-backend-module-catalog';
+-import { graphqlPlugin } from '@frontside/backstage-plugin-graphql-backend';
+-import { graphqlModuleCatalog } from '@frontside/backstage-plugin-graphql-backend-module-catalog';
 
 const backend = createBackend();
 
 
-- backend.add(graphqlPlugin());
-+ backend.add(import('@frontside/backstage-plugin-graphql-backend'));
-- backend.add(graphqlModuleCatalog());
-+ backend.add(import('@frontside/backstage-plugin-graphql-backend-module-catalog'));
+-backend.add(graphqlPlugin());
++backend.add(import('@frontside/backstage-plugin-graphql-backend'));
+-backend.add(graphqlModuleCatalog());
++backend.add(import('@frontside/backstage-plugin-graphql-backend-module-catalog'));
 
 backend.start();
 ```

--- a/.changeset/slimy-cooks-relate.md
+++ b/.changeset/slimy-cooks-relate.md
@@ -1,0 +1,24 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+'@frontside/backstage-plugin-graphql-backend': patch
+---
+
+Make module default exports to allow using import syntax
+
+This change allows to use import syntax to load modules
+
+```ts
+import { createBackend } from '@backstage/backend-defaults';
+- import { graphqlPlugin } from '@frontside/backstage-plugin-graphql-backend';
+- import { graphqlModuleCatalog } from '@frontside/backstage-plugin-graphql-backend-module-catalog';
+
+const backend = createBackend();
+
+
+- backend.add(graphqlPlugin());
++ backend.add(import('@frontside/backstage-plugin-graphql-backend'));
+- backend.add(graphqlModuleCatalog());
++ backend.add(import('@frontside/backstage-plugin-graphql-backend-module-catalog'));
+
+backend.start();
+```

--- a/plugins/graphql-backend-module-catalog/src/index.ts
+++ b/plugins/graphql-backend-module-catalog/src/index.ts
@@ -4,3 +4,4 @@ export * from './relation';
 export * from './catalogModule';
 export * from './relationModule';
 export * from './entitiesLoadFn';
+export { graphqlModuleCatalog as default } from './catalogModule';

--- a/plugins/graphql-backend/src/index.ts
+++ b/plugins/graphql-backend/src/index.ts
@@ -1,3 +1,4 @@
 export * from './graphql';
 export * from './router';
 export * from '@frontside/backstage-plugin-graphql-backend-node';
+export { graphqlPlugin as default } from './graphql';


### PR DESCRIPTION
## Motivation

To play nicely with Backstage's Backend Extension system, modules have to export as default. This will allow them to be imported using `import` syntax and eventually dynamically.

## Approach

Added default exports for GraphQL modules. A package can only have one export, so we'd need to create another entry point if we want to allow the registering relations module.
