### PR TITLE
fix(humanitec-backend): handle disconnects while fetching

### DIFF
--- a/.changeset/strong-kings-pay.md
+++ b/.changeset/strong-kings-pay.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-humanitec-backend': patch
+---
+
+Handle disconnects while fetching app info

--- a/plugins/humanitec-backend/src/service/app-info-service.test.ts
+++ b/plugins/humanitec-backend/src/service/app-info-service.test.ts
@@ -4,8 +4,10 @@ import * as common from '@frontside/backstage-plugin-humanitec-common';
 import { AppInfoService } from './app-info-service';
 
 const fetchInterval = 50;
+const slowFetchTimeout = 100;
 
 let returnError = false;
+let slowFetch = false
 const fakeAppInfo = { fake: 'res' }
 const fakeError = new Error('fake error');
 
@@ -16,6 +18,10 @@ jest.mock('@frontside/backstage-plugin-humanitec-common', () => ({
       throw fakeError;
     }
 
+    if (slowFetch) {
+      await setTimeout(100);
+    }
+
     return fakeAppInfo;
   }),
 }))
@@ -24,6 +30,7 @@ describe('AppInfoService', () => {
   afterEach(() => {
     jest.clearAllMocks();
     returnError = false;
+    slowFetch = false;
   });
 
   it('single subscriber', async () => {
@@ -52,7 +59,7 @@ describe('AppInfoService', () => {
     expect(common.createHumanitecClient).toHaveBeenCalledTimes(2);
   });
 
-  it('single subscriber, recovers after an erro', async () => {
+  it('single subscriber, recovers after an error', async () => {
     returnError = true
 
     const service = new AppInfoService('token', fetchInterval);
@@ -82,6 +89,27 @@ describe('AppInfoService', () => {
     expect(common.createHumanitecClient).toHaveBeenCalledTimes(2);
   });
 
+  it('single subscriber, disconnects with slow fetch', async () => {
+    slowFetch = true
+
+    const service = new AppInfoService('token', fetchInterval);
+    const subscriber = jest.fn();
+
+    const close = service.addSubscriber('orgId', 'appId', subscriber);
+
+    await setTimeout(slowFetchTimeout / 2);
+
+    expect(subscriber).toHaveBeenCalledTimes(0);
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(1);
+
+    close();
+
+    // Wait for two cycles to ensure that the fetch is not retried.
+    await setTimeout((slowFetchTimeout + fetchInterval) * 2);
+
+    expect(common.createHumanitecClient).toHaveBeenCalledTimes(1);
+  });
+
   it('two subscribers', async () => {
     const service = new AppInfoService('token', fetchInterval);
     const subscriber1 = jest.fn();
@@ -90,7 +118,7 @@ describe('AppInfoService', () => {
     const close1 = service.addSubscriber('orgId', 'appId', subscriber1);
     const close2 = service.addSubscriber('orgId', 'appId', subscriber2);
 
-    await setTimeout(10);
+    await setTimeout(fetchInterval);
 
     expect(subscriber1).toHaveBeenCalledTimes(1);
     expect(subscriber2).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Motivation

When a client disconnected during fetching, the timeout was reset and the plugin continued to poll in a loop without any connected clients.


