### PR TITLE
Pass Backstage Auth token to `catalog.queryEntities`

### DIFF
--- a/.changeset/fair-taxis-burn.md
+++ b/.changeset/fair-taxis-burn.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+---
+
+Pass Backstage Auth token to `catalog.queryEntities`


### PR DESCRIPTION
## Motivation

Forgot to pass an auth token to catalog client method for `entities` query 

## Approach

Pass a token from the request