### PR TITLE
Fix text search property name for a cursor

### DIFF
--- a/.changeset/small-days-double.md
+++ b/.changeset/small-days-double.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+---
+
+Fix text search property name for a cursor

--- a/plugins/graphql-backend-module-catalog/src/resolvers.ts
+++ b/plugins/graphql-backend-module-catalog/src/resolvers.ts
@@ -26,7 +26,7 @@ interface CatalogCursor {
   totalItems?: number;
   isPrevious: boolean;
   orderFields?: Array<{ field: string; order: 'asc' | 'desc' }>;
-  fullTextSearch?: { term: string; fields?: string[] };
+  fullTextFilter?: { term: string; fields?: string[] };
   filter?: { anyOf: Array<{ allOf: { key: string; values: string[] }[] }> };
 }
 
@@ -425,8 +425,7 @@ export const queryResolvers: () => Resolvers = () => {
           }
           return [{ field: 'metadata.uid', order: 'asc' }];
         })();
-
-        const fullTextSearch = (() => {
+        const fullTextFilter = (() => {
           if (rawFilter?.fullTextFilter) {
             return {
               term: rawFilter.fullTextFilter.term,
@@ -466,7 +465,7 @@ export const queryResolvers: () => Resolvers = () => {
 
         Object.assign(cursorObject, {
           orderFields,
-          fullTextSearch,
+          fullTextFilter,
           filter: queryFilter,
         });
       }


### PR DESCRIPTION
## Motivation

Text search doesn't work as expected for `entities` graphql query. The reason why it did happen was wrong field name for a cursor

## Approach

Renamed the field