### PR TITLE
Add ability to override Catalog GraphQL module schema

### DIFF
--- a/.changeset/seven-frogs-stare.md
+++ b/.changeset/seven-frogs-stare.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql-backend-module-catalog': patch
+---
+
+Add ability to override Catalog GraphQL module schema

--- a/plugins/graphql-backend-module-catalog/src/catalog/catalog.ts
+++ b/plugins/graphql-backend-module-catalog/src/catalog/catalog.ts
@@ -1,4 +1,4 @@
-import { createModule } from 'graphql-modules';
+import { TypeDefs, createModule } from 'graphql-modules';
 import { loadFilesSync } from '@graphql-tools/load-files';
 import { resolvePackagePath } from '@backstage/backend-common';
 import { Relation } from '../relation';
@@ -11,14 +11,14 @@ const catalogSchemaPath = resolvePackagePath(
 );
 
 /** @public */
-export const Catalog = (): GraphQLModule => ({
+export const Catalog = ({ typeDefs }: { typeDefs?: TypeDefs } = {}): GraphQLModule => ({
   mappers: { ...Relation().mappers },
   postTransform: Relation().postTransform,
   module: createModule({
     id: 'catalog-entities',
     typeDefs: [
       ...Relation().module.typeDefs,
-      ...loadFilesSync(catalogSchemaPath),
+      ...typeDefs ? [typeDefs].flat() : loadFilesSync(catalogSchemaPath),
     ],
     resolvers: {
       ...Relation().module.config.resolvers,

--- a/plugins/graphql-backend-module-catalog/src/catalogModule.ts
+++ b/plugins/graphql-backend-module-catalog/src/catalogModule.ts
@@ -21,7 +21,7 @@ export const graphqlModuleCatalog = createBackendModule({
         context: graphqlContextExtensionPoint,
       },
       async init({ catalog, modules, loaders, context }) {
-        modules.addModules([Catalog]);
+        modules.addModules([Catalog()]);
         loaders.addLoaders(createCatalogLoader(catalog));
         context.setContext(ctx => ({ ...ctx, catalog }));
       },


### PR DESCRIPTION
## Motivation

The GraphQL schema doesn't allow to override type of a field while merging, which is required in some cases.

## Approach

Add ability to provide custom Catalog schema
