### PR TITLE
Deprecate humanitec plugins because hey have their own repo  now

### DIFF
--- a/plugins/humanitec-backend/package.json
+++ b/plugins/humanitec-backend/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@frontside/backstage-plugin-humanitec-backend",
+  "deprecate": "Deprecated in favor of @humanitec/backstage-plugin-backend",
   "version": "0.3.17",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/plugins/humanitec-common/package.json
+++ b/plugins/humanitec-common/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@frontside/backstage-plugin-humanitec-common",
+  "deprecate": "Deprecated in favor of @humanitec/backstage-plugin-common",
   "description": "Humanitec API Client",
   "version": "0.3.13",
   "main": "src/index.ts",

--- a/plugins/humanitec/package.json
+++ b/plugins/humanitec/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@frontside/backstage-plugin-humanitec",
+  "deprecate": "Deprecated in favor of @humanitec/backstage-plugin",
   "version": "0.3.15",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Motivation

Humanitec folks are maintaining their plugins in https://github.com/humanitec/humanitec-backstage-plugins we can deprecate these now.

## Approach

Added deprecate messages to each package in package.json