### PR TITLE
Add CSRF prevention plugin for graphql-yoga

### DIFF
--- a/.changeset/nice-wolves-carry.md
+++ b/.changeset/nice-wolves-carry.md
@@ -1,0 +1,5 @@
+---
+'@frontside/backstage-plugin-graphql-backend': patch
+---
+
+Add CSRF prevention plugin for graphql-yoga

--- a/plugins/graphql-backend/package.json
+++ b/plugins/graphql-backend/package.json
@@ -46,6 +46,7 @@
     "@envelop/graphql-modules": "^5.0.0",
     "@frontside/backstage-plugin-graphql-backend-node": "^0.1.7",
     "@frontside/hydraphql": "^0.1.3",
+    "@graphql-yoga/plugin-csrf-prevention": "^3.7.0",
     "dataloader": "^2.1.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
@@ -63,5 +64,8 @@
   "files": [
     "dist",
     "docs"
-  ]
+  ],
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/plugins/graphql-backend/src/router.ts
+++ b/plugins/graphql-backend/src/router.ts
@@ -10,6 +10,7 @@ import { useGraphQLModules } from '@envelop/graphql-modules';
 import { useDataLoader } from '@envelop/dataloader';
 import { printSchema } from 'graphql';
 import { GraphQLAppOptions } from '@frontside/backstage-plugin-graphql-backend-node';
+import { useCSRFPrevention } from '@graphql-yoga/plugin-csrf-prevention';
 import {
   createLoader,
   createGraphQLApp,
@@ -78,6 +79,7 @@ export async function createRouter({
     if (!yoga) {
       yoga = createYoga({
         plugins: [
+          useCSRFPrevention(),
           useGraphQLModules(application),
           useDataLoader(
             'loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6397,6 +6397,11 @@
   dependencies:
     tslib "^2.5.2"
 
+"@graphql-yoga/plugin-csrf-prevention@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@graphql-yoga/plugin-csrf-prevention/-/plugin-csrf-prevention-3.7.0.tgz#f48acc57796809041000c02c327f924baa522b49"
+  integrity sha512-QDl+pGY4ZcIlFqkpZc8PAF/Zwk/ve1E+5V5O7Af0lBjuq+MEACZHMrac8pV/h57JS13fwBt2Sss3urb9L+xq/A==
+
 "@graphql-yoga/subscription@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@graphql-yoga/subscription/-/subscription-4.0.0.tgz#2bf5844ce8aeff46332650ad642218250201dcc5"
@@ -11505,7 +11510,14 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@18.2.22", "@types/react-dom@<18.0.0", "@types/react-dom@^17":
+"@types/react-dom@18.2.22":
+  version "18.2.22"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.22.tgz#d332febf0815403de6da8a97e5fe282cbe609bae"
+  integrity sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-dom@<18.0.0":
   version "17.0.25"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.25.tgz#e0e5b3571e1069625b3a3da2b279379aa33a0cb5"
   integrity sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==
@@ -17963,10 +17975,20 @@ graphql-yoga@^4.0.3:
     lru-cache "^10.0.0"
     tslib "^2.5.2"
 
-graphql@*, graphql@16.5.0, "graphql@^15.0.0 || ^16.0.0", graphql@^15.5.0, graphql@^15.5.1, graphql@^16.0.0, graphql@^16.3.0, graphql@^16.5.0, graphql@^16.6.0:
+graphql@*, "graphql@^15.0.0 || ^16.0.0", graphql@^16.0.0, graphql@^16.3.0, graphql@^16.5.0, graphql@^16.6.0:
   version "16.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.0.tgz#374478b7f27b2dc6153c8f42c1b80157f79d79d4"
   integrity sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==
+
+graphql@16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
+  integrity sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==
+
+graphql@^15.5.0, graphql@^15.5.1:
+  version "15.9.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.9.0.tgz#4e8ca830cfd30b03d44d3edd9cac2b0690304b53"
+  integrity sha512-GCOQdvm7XxV1S4U4CGrsdlEN37245eC8P9zaYCMr6K1BG0IPGy5lUwmJsEOGyl1GD6HXjOtl2keCP9asRBwNvA==
 
 gtoken@^7.0.0:
   version "7.1.0"
@@ -29139,7 +29161,12 @@ yaml-ast-parser@^0.0.43:
   resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
   integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
 
-yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2, yaml@^2.0.0, yaml@^2.1.3, yaml@^2.2.1, yaml@^2.2.2, yaml@^2.3.1:
+yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.0.0, yaml@^2.1.3, yaml@^2.2.1, yaml@^2.2.2, yaml@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.2.tgz#f522db4313c671a0ca963a75670f1c12ea909144"
   integrity sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==


### PR DESCRIPTION
**Signed-off-by**: Dmitriy Lazarev <w@kich.dev>
**Found by**: Ali Basma from X41-Dsec GmBh

## Motivation

Recently Backstage-core team contacted with me to notify that our graphql plugin doesn't prevent CSFR attack https://the-guild.dev/graphql/yoga-server/docs/features/csrf-prevention

## Approach

Added graphql-yoga plugin to prevent CSRF

